### PR TITLE
Export Honeybadger

### DIFF
--- a/packages/logging/src/logging.ts
+++ b/packages/logging/src/logging.ts
@@ -1,6 +1,6 @@
-import * as Honeybadger from "honeybadger-js";
+import * as Honeybadger from 'honeybadger-js';
 
-const defaultPrefix = "[EXO]";
+const defaultPrefix = '[EXO]';
 
 export const logger = (prefix: string) => (...messages: any): void => {
   console.log(prefix, ...messages);
@@ -14,11 +14,9 @@ export const log = logger(defaultPrefix);
 
 export const warn = warner(defaultPrefix);
 
-export const warnAndNotify = (
-  errorName: string,
-  message: string,
-  context: {}
-): void => {
+export const warnAndNotify = (errorName: string, message: string, context: {}): void => {
   warn(message);
   Honeybadger.notify(errorName, message, { context });
 };
+
+export { Honeybadger };


### PR DESCRIPTION
The `warnAndNotify` function won't work unless the caller has configured the same instance of Honeybadger that this package uses. Exporting it here allows that to be done easily.

TECH-382 ([card](https://execonline.atlassian.net/browse/TECH-382), [map](https://execonline.atlassian.net/wiki/spaces/TEC/pages/1391689740))

I've tested the configuration of P3 locally with these changes and it fixes the issue.