### PR TITLE
Update translations library for use with React Native

### DIFF
--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -30,7 +30,7 @@
     "@execonline-inc/maybe-adapter": "^3.0.0",
     "@kofno/piper": "^1.2.0",
     "ajaxian": "^3.0.1",
-    "jsonous": "^5.1",
+    "jsonous": "^5.2",
     "logging": "^3.2.0",
     "maybeasy": "^2.6.0",
     "resulty": "^3.0.0",

--- a/packages/collections/yarn.lock
+++ b/packages/collections/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@execonline-inc/maybe-adapter@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/maybe-adapter/-/maybe-adapter-2.0.0.tgz#c7e7610f56a159475ed9333c6e1e1bef3e3ca4ba"
-  integrity sha512-/CABMAQlr2X4bXZMwU3RKxqJxnW3MjhxYOVzPQC3N/rXvUFVoATWxZQr23wEtwEI344sxUhbIq3idlHFTeRxag==
+"@execonline-inc/maybe-adapter@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@execonline-inc/maybe-adapter/-/maybe-adapter-3.0.0.tgz#c852989d2f7e043cd04d52fb7da4d541bef4d503"
+  integrity sha512-iwqCdigbBEcL034TL4taAeRkaz78mpwYwZZL9CgEU8xsBNs1WEROpWOYKax0Gp39aX3ASdUr1ojB8gO9kBMbOw==
   dependencies:
     "@kofno/piper" "^1.2.0"
     ajaxian "^3.0.1"
-    jsonous "^5.1"
+    jsonous "^5.2"
     logging "^3.2.0"
     maybeasy "^2.6.0"
     resulty "^3.0.0"
@@ -49,6 +49,11 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+date-fns@^2.16.1:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.19.0.tgz#65193348635a28d5d916c43ec7ce6fbd145059e1"
+  integrity sha512-X3bf2iTPgCAQp9wvjOQytnf5vO5rESYRXlPIVcgSbtT5OTScPcsf9eZU+B/YIkKAtYr5WeCii58BgATrNitlWg==
+
 debug@^2.6.1:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -73,11 +78,12 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-jsonous@^5.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/jsonous/-/jsonous-5.1.0.tgz#eda2c5e29df19c982483508c3f33142633c6b859"
-  integrity sha512-kq0Lg9zJx3k2J+bz+r4qutqwNEw0cbaeBC+atjTUMjykZSb6fvE7lDDhtFR0/ORS1+nOaxXR5zxQhTm14OYRHg==
+jsonous@^5.2:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/jsonous/-/jsonous-5.2.0.tgz#206d04ae0ea76001a4c313d6241ce550b7cff22e"
+  integrity sha512-GkWqc24vIKdi/4hWaT+3AcLje6DYFug4rOl1MrkLK2xa3qRYV3gGMfX/CVlswiRo2gda1Dkzb2tkni4WeF2PoQ==
   dependencies:
+    date-fns "^2.16.1"
     maybeasy "^2.6.0"
     resulty "^3.0.0"
     weakset "^1.0.0"

--- a/packages/translations/package.json
+++ b/packages/translations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@execonline-inc/translations",
-  "version": "6.0.0",
+  "version": "5.0.0",
   "description": "Support for typed and interpolatable translations",
   "author": "Patrick Rebsch <pjrebsch@gmail.com>",
   "homepage": "https://github.com/execonline-inc/CooperTS#readme",

--- a/packages/translations/package.json
+++ b/packages/translations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@execonline-inc/translations",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Support for typed and interpolatable translations",
   "author": "Patrick Rebsch <pjrebsch@gmail.com>",
   "homepage": "https://github.com/execonline-inc/CooperTS#readme",
@@ -31,19 +31,16 @@
     "@execonline-inc/logging": "^4.0.0",
     "@execonline-inc/maybe-adapter": "^3.0.0",
     "@kofno/piper": "^1.2.0",
+    "@prebsch-exo/i18next": "19.9.2-patch.1",
     "@types/react": "^16.9.23",
     "htmlparser2": "^4.1.0",
-    "i18next": "^19.0.3",
-    "i18next-browser-languagedetector": "^4.0.1",
-    "i18next-locize-backend": "^1.3.0",
-    "i18next-xhr-backend": "^3.2.2",
     "jsonous": "^5.2",
     "maybeasy": "^2.6.0",
     "mobx-react": "^5.4.4",
     "nonempty-list": "^1.0.5",
     "react": "^16.13.0",
     "resulty": "^3.0.0",
-    "taskarian": "^2.1.0"
+    "taskarian": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/translations/src/AlreadyTranslated.tsx
+++ b/packages/translations/src/AlreadyTranslated.tsx
@@ -6,6 +6,6 @@ interface Props {
   content: AlreadyTranslatedText;
 }
 
-const AlreadyTranslated: React.SFC<Props> = ({ content }) => <>{content.text}</>;
+const AlreadyTranslated: React.FC<Props> = ({ content }) => <>{content.text}</>;
 
 export default observer(AlreadyTranslated);

--- a/packages/translations/src/L.tsx
+++ b/packages/translations/src/L.tsx
@@ -9,7 +9,7 @@ export interface Props {
   format: LocalizationFormat;
 }
 
-const L: React.SFC<Props> = ({ localizeable, format }) => (
+const L: React.FC<Props> = ({ localizeable, format }) => (
   <TranslationsContext.Consumer>{localizer(localizeable, format)}</TranslationsContext.Consumer>
 );
 

--- a/packages/translations/src/NotTranslated.tsx
+++ b/packages/translations/src/NotTranslated.tsx
@@ -5,6 +5,6 @@ interface Props {
   text: string;
 }
 
-const NotTranslated: React.SFC<Props> = ({ text }) => <>{text}</>;
+const NotTranslated: React.FC<Props> = ({ text }) => <>{text}</>;
 
 export default observer(NotTranslated);

--- a/packages/translations/src/TranslationsLoader.tsx
+++ b/packages/translations/src/TranslationsLoader.tsx
@@ -1,6 +1,5 @@
 import { warn } from '@execonline-inc/logging';
 import * as React from 'react';
-import { loaded, loadedFromFallback } from './translations';
 import TranslationsContext from './TranslationsContext';
 import { Loader, TranslationsState } from './types';
 
@@ -37,11 +36,11 @@ class TranslationsLoader extends React.Component<Props, State> {
 
   componentDidMount() {
     this.props.loader.fork(
-      ({ t, lng, failure }) => {
-        warn(`Translations: ${failure}. Falling back to default language.`);
-        this.setState({ translations: loadedFromFallback(t, lng, failure) });
+      loadedFromFallback => {
+        warn(`Translations: ${loadedFromFallback.error}. Falling back to default language.`);
+        this.setState({ translations: loadedFromFallback });
       },
-      ({ t, lng }) => this.setState({ translations: loaded(t, lng) })
+      loaded => this.setState({ translations: loaded })
     );
   }
 

--- a/packages/translations/src/adapters/i18next/index.ts
+++ b/packages/translations/src/adapters/i18next/index.ts
@@ -1,0 +1,33 @@
+import { warn } from '@execonline-inc/logging';
+import { noop } from '@kofno/piper';
+import i18next, * as i18n from '@prebsch-exo/i18next';
+import Task from 'taskarian';
+import { loaded, loadedFromFallback } from '../../translations';
+import { Loader } from '../../types';
+
+export const defaultSettings: i18n.InitOptions = {
+  fallbackLng: 'en',
+  ns: ['translations'],
+  defaultNS: 'translations',
+  debug: true,
+  keySeparator: false,
+  nsSeparator: false,
+  interpolation: {
+    escapeValue: false,
+  },
+};
+
+export const initTask = (initializer: i18n.i18n, options: i18n.InitOptions): Loader =>
+  new Task((reject, resolve) => {
+    initializer
+      .init(options, (err, translator) => {
+        if (err) {
+          reject(loadedFromFallback(translator, i18next.language, String(err)));
+        } else {
+          resolve(loaded(translator, i18next.language));
+        }
+      })
+      .catch(err => warn(err));
+
+    return noop;
+  });

--- a/packages/translations/src/index.ts
+++ b/packages/translations/src/index.ts
@@ -3,6 +3,7 @@ import NotTranslated from './NotTranslated';
 import TranslationsContext from './TranslationsContext';
 import TranslationsLoader from './TranslationsLoader';
 
+export * from './adapters/i18next';
 export * from './decoders';
 export * from './translations';
 export * from './types';

--- a/packages/translations/src/localizations.ts
+++ b/packages/translations/src/localizations.ts
@@ -118,7 +118,7 @@ export const localizer = (localizeable: Localizeable, format: LocalizationFormat
   switch (ts.kind) {
     case 'loaded-from-fallback':
     case 'loaded':
-      return localization(localizeable, format, ts.results.lng);
+      return localization(localizeable, format, ts.language);
     case 'uninitialized':
       warn('localization is uninitialized');
       return String(localizeable);

--- a/packages/translations/src/types.ts
+++ b/packages/translations/src/types.ts
@@ -1,23 +1,8 @@
-import { i18n, TFunction } from 'i18next';
 import * as React from 'react';
 import Task from 'taskarian';
 import { Props as LProps } from './L';
 
-export interface Config {
-  loadPath: string;
-  loadCallback: (i18n: i18n) => void;
-}
-
-export interface I18nResults {
-  t: TFunction;
-  lng: string;
-}
-
-export interface LoadedI18n extends I18nResults {}
-
-export interface FallBackI18n extends I18nResults {
-  failure: string;
-}
+export type Translator = (translationKey: string, options: {}) => string;
 
 export interface Uninitialized {
   kind: 'uninitialized';
@@ -25,12 +10,14 @@ export interface Uninitialized {
 
 export interface Loaded {
   kind: 'loaded';
-  results: LoadedI18n;
+  translator: Translator;
+  language: string;
 }
 
 export interface LoadedFromFallback {
   kind: 'loaded-from-fallback';
-  results: FallBackI18n;
+  translator: Translator;
+  language: string;
   error: string;
 }
 
@@ -91,17 +78,16 @@ export type ParameterizedFn<
   ParameterizedPropsT extends ParameterizedProps<ParameterizedKeyT>
 > = (t: ParameterizedPropsT) => Parameterized<ParameterizedKeyT, ParameterizedPropsT>;
 
-export type Loader = Task<FallBackI18n, LoadedI18n>;
+export type Loader = Task<LoadedFromFallback, Loaded>;
 
 export interface TranslationsF<KeyT, PropsT, ParameterizedValuesT> {
-  loader: Loader;
-  L: React.SFC<LProps>;
+  L: React.FC<LProps>;
   translation: (
     text: KeyT,
     interpolation?: Partial<ParameterizedValuesT>
   ) => (ts: TranslationsState) => string;
   translator: (tProps: PropsT) => (ts: TranslationsState) => React.ReactNode;
-  T: React.SFC<PropsT>;
+  T: React.FC<PropsT>;
 }
 
 type DateFormat =

--- a/packages/translations/yarn.lock
+++ b/packages/translations/yarn.lock
@@ -2,17 +2,73 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.10.1", "@babel/runtime@^7.5.5":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
-  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+"@babel/runtime@^7.12.0":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
   dependencies:
     regenerator-runtime "^0.13.4"
+
+"@execonline-inc/collections@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@execonline-inc/collections/-/collections-4.0.0.tgz#93d68a56b53f4ac2bda7a0a89918e5c6c97bca3d"
+  integrity sha512-U0yRDzGe1oXLzwD/odiN8YgBy58LqvoqaZRRP/fYe4s/a8+HBwnobgHDNyp8Ud4IWxDsou72P+t97gOvMNbJrQ==
+  dependencies:
+    "@execonline-inc/maybe-adapter" "^3.0.0"
+    "@kofno/piper" "^1.2.0"
+    ajaxian "^3.0.1"
+    jsonous "^5.1"
+    logging "^3.2.0"
+    maybeasy "^2.6.0"
+    resulty "^3.0.0"
+    taskarian "^3.0"
+
+"@execonline-inc/environment@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@execonline-inc/environment/-/environment-4.0.0.tgz#d523b0b194d41e3ecf14599749e9f001645ce81f"
+  integrity sha512-kQSw+rUdmYkB84bNLcOIecSneD8g0cVGeD/uZkwCx7n9aYhh+GxNRAgaM6LroSkl6y+T0Etbrg2TVooF0T/IBg==
+  dependencies:
+    "@kofno/piper" "^1.2.0"
+    ajaxian "^3.0.1"
+    honeybadger-js "^2.0.0"
+    jsonous "^5.2"
+    logging "^3.2.0"
+    maybeasy "^2.6.0"
+    resulty "^3.0.0"
+    taskarian "3.0.0"
+
+"@execonline-inc/logging@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@execonline-inc/logging/-/logging-4.0.0.tgz#231b10cefb3dc07f225b5f12d0865b8ce8ac80e7"
+  integrity sha512-Wm9scYv1v69C5lHZZG0qLjHv76BvTlak50d6NI+yMjX8gC+ULTZ6v9IV+NHzcL2xLDFIWmqDKRyShzNzJ9YUvg==
+  dependencies:
+    "@execonline-inc/environment" "^4.0.0"
+    logging "^3.2.0"
+
+"@execonline-inc/maybe-adapter@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@execonline-inc/maybe-adapter/-/maybe-adapter-3.0.0.tgz#c852989d2f7e043cd04d52fb7da4d541bef4d503"
+  integrity sha512-iwqCdigbBEcL034TL4taAeRkaz78mpwYwZZL9CgEU8xsBNs1WEROpWOYKax0Gp39aX3ASdUr1ojB8gO9kBMbOw==
+  dependencies:
+    "@kofno/piper" "^1.2.0"
+    ajaxian "^3.0.1"
+    jsonous "^5.2"
+    logging "^3.2.0"
+    maybeasy "^2.6.0"
+    resulty "^3.0.0"
+    taskarian "^3.0"
 
 "@kofno/piper@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@kofno/piper/-/piper-1.2.0.tgz#c1f9903664ed90f105130580d3570bc747d7c028"
   integrity sha512-3XgONyr071OX8+olAzYhF+mYxlSo3X9ySyNEmbXtzhyj1hAM+MPYB+bK4gZhrumSTfzYZt4lv9fUAgz8+P6XBQ==
+
+"@prebsch-exo/i18next@19.9.2-patch.1":
+  version "19.9.2-patch.1"
+  resolved "https://registry.yarnpkg.com/@prebsch-exo/i18next/-/i18next-19.9.2-patch.1.tgz#2969f2e2ef099b92ca52620dfe15ee4449bcde4b"
+  integrity sha512-jovnIKWPOQ9rKs9fPjEzDlwvtcY4AR+/FoWCNC5gjtoKSyEFr1isxChEdr3ysiVlVmsuaRLO9TjGWWoN9GA8cQ==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -27,6 +83,46 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
+ajaxian@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ajaxian/-/ajaxian-3.1.0.tgz#b207c64155f80f97525dbd47f66533213f9372e3"
+  integrity sha512-Z+nn1rkRujF2k4hjfxslPOoUp2RZVbbs2BrSc0h89hc31O+rH0yfLKa76WK6GXZG6el6cG3ECQZS0ynMFdQgrg==
+  dependencies:
+    resulty latest
+    taskarian "^3.0.0"
+
+ansi-styles@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
+
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
+chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
 csstype@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
@@ -36,6 +132,13 @@ date-fns@^2.16.1:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
+
+debug@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
 
 dom-serializer@^0.2.1:
   version "0.2.2"
@@ -71,12 +174,27 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
   integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
+esutils@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
 hoist-non-react-statics@^3.0.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
   dependencies:
     react-is "^16.7.0"
+
+honeybadger-js@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/honeybadger-js/-/honeybadger-js-2.3.0.tgz#040200066d60a8c1eca036e9f8568f9cff8b8d55"
+  integrity sha512-Tq1jPNumPe/l5RRDPDi+KNGULoaJQ9BSVZC+TEZOlPUzJx3AUn5ESb2NkCd7oSx/J221/aWUfz2/JrltHldx7A==
 
 htmlparser2@^4.1.0:
   version "4.1.0"
@@ -88,38 +206,12 @@ htmlparser2@^4.1.0:
     domutils "^2.0.0"
     entities "^2.0.0"
 
-i18next-browser-languagedetector@^4.0.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-4.3.1.tgz#005d2db6204b0a4af5f01c7987f5ccaf4ef97da5"
-  integrity sha512-KIToAzf8zwWvacgnRwJp63ase26o24AuNUlfNVJ5YZAFmdGhsJpmFClxXPuk9rv1FMI4lnc8zLSqgZPEZMrW4g==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-
-i18next-locize-backend@^1.3.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/i18next-locize-backend/-/i18next-locize-backend-1.9.0.tgz#27bb6d2224b29c11c1774df0fbcfc6eee1fa49ae"
-  integrity sha512-h0uiLYxhMA+MJp0iMTXl2j4gdEEeZ2tR9LIPNtrQ5cV+2wvbfhQkZuP9xtv5CRZdAVGQkc3q+BZu4/EQ2aAkyQ==
-
-i18next-xhr-backend@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/i18next-xhr-backend/-/i18next-xhr-backend-3.2.2.tgz#769124441461b085291f539d91864e3691199178"
-  integrity sha512-OtRf2Vo3IqAxsttQbpjYnmMML12IMB5e0fc5B7qKJFLScitYaXa1OhMX0n0X/3vrfFlpHL9Ro/H+ps4Ej2j7QQ==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-
-i18next@^19.0.3:
-  version "19.6.3"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.6.3.tgz#ce2346161b35c4c5ab691b0674119c7b349c0817"
-  integrity sha512-eYr98kw/C5z6kY21ti745p4IvbOJwY8F2T9tf/Lvy5lFnYRqE45+bppSgMPmcZZqYNT+xO0N0x6rexVR2wtZZQ==
-  dependencies:
-    "@babel/runtime" "^7.10.1"
-
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-jsonous@^5.2:
+jsonous@^5.1, jsonous@^5.2:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/jsonous/-/jsonous-5.2.0.tgz#206d04ae0ea76001a4c313d6241ce550b7cff22e"
   integrity sha512-GkWqc24vIKdi/4hWaT+3AcLje6DYFug4rOl1MrkLK2xa3qRYV3gGMfX/CVlswiRo2gda1Dkzb2tkni4WeF2PoQ==
@@ -128,6 +220,15 @@ jsonous@^5.2:
     maybeasy "^2.6.0"
     resulty "^3.0.0"
     weakset "^1.0.0"
+
+logging@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/logging/-/logging-3.3.0.tgz#5743f9154f790308c5d6f2e28196dd0259fcf0ad"
+  integrity sha512-Hnmu3KlGTbXMVS7ONjBpnjjiF9cBlK5qsmj77sOcqRkNpvO9ouUGPKe2PmBCWWYpKAbxb96b08cYEv4hiBk3lQ==
+  dependencies:
+    chalk "^4.1.0"
+    debug "^4.3.1"
+    nicely-format "^1.1.0"
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -148,6 +249,19 @@ mobx-react@^5.4.4:
   dependencies:
     hoist-non-react-statics "^3.0.0"
     react-lifecycles-compat "^3.0.2"
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+nicely-format@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/nicely-format/-/nicely-format-1.1.0.tgz#6c3513d1f38077d65ed9721e716a8e1917ba27b6"
+  integrity sha1-bDUT0fOAd9Ze2XIecWqOGRe6J7Y=
+  dependencies:
+    ansi-styles "^2.2.1"
+    esutils "^2.0.2"
 
 nonempty-list@^1.0.5:
   version "1.0.5"
@@ -195,15 +309,24 @@ regenerator-runtime@^0.13.4:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
-resulty@^3.0.0:
+resulty@^3.0.0, resulty@latest:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resulty/-/resulty-3.0.0.tgz#2f852a51f18dd528f43bb7f5ae02a88eaef5bd59"
   integrity sha512-rdAnIuIC8WMfnlqktJfZz+83djxwQwzVlXnlCRb2h0Zxqzazjp+1z9cfDVmiIWBnjhrcERw3PBK7s+YJ83f2aw==
 
-taskarian@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-2.1.0.tgz#f4264ed0a6c1f8e6caaef3ba36b8921c9e57822b"
-  integrity sha512-OATHkWTfCGIkP295DUxW7sh6U+rJM7yer8O1nNV72FNnFemYhTD5NNsMXB2GIHYKZukYRUfEzV5Enh81XtrSXQ==
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+taskarian@3.0.0, taskarian@^3.0, taskarian@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-3.0.0.tgz#a209c00594b48243229116f526d5f820feb9f3de"
+  integrity sha512-BOmlfeNUmsNuCL05gjfROSVAk5i4ZgqEG+1wEJ1/JG/t9yOkTK8WxUKv2qEL7lhNjMqEbyuQ8SqlO8Ky9VMdDg==
+  dependencies:
+    resulty "^3.0.0"
 
 weakset@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
https://execonline.atlassian.net/browse/TECH-1720

Primarily, this updates the translations library to use patched versions of the `i18next` dependencies so that they export properly when bundled for React Native.

Additionally, this loosens the coupling to the implementation details of i18next. This was partially necessitated by the fact that some i18next functionality that was embedded in this library is not applicable on mobile, so this allows the user of the library to handle that logic as it needs to, and allows for greater flexibility and configuration of i18next in other ways, or can allow for the use of a different underlying translation library altogether.

For the fixes in these patched dependencies, see:

https://github.com/pjrebsch/i18next/pull/1
https://github.com/pjrebsch/i18next-http-backend/pull/1
https://github.com/pjrebsch/i18next-browser-languageDetector/pull/1