### PR TITLE
Add function to reduce array of Maybes to values

### DIFF
--- a/packages/maybe-adapter/README.md
+++ b/packages/maybe-adapter/README.md
@@ -6,7 +6,7 @@ The `maybe-adapter` package provides functions to convert to/from `Maybe` types.
 
 ### `toResult`
 
-This function has a curried and non-curried form. It takes an error and a `Maybe`. When the `Maybe` is a `Just`, a successful `Result` is returned with the wrapped value, otherwise an error `Result` is returned with the given error value.
+This function takes an error and a `Maybe`. When the `Maybe` is a `Just`, a successful `Result` is returned with the wrapped value, otherwise an error `Result` is returned with the given error value. It has a curried and non-curried form.
 
 ```ts
 import { toResult } from '@execonline-inc/maybe-adapter';
@@ -17,7 +17,7 @@ toResult<string, number>('an error message')(nothing());
 
 ### `toTask`
 
-This function has a curried and non-curried form. It takes an error and a `Maybe`. When the `Maybe` is a `Just`, a succeeding `Task` is returned with the wrapped value, otherwise a failing `Task` is returned with the given error value.
+This function takes an error and a `Maybe`. When the `Maybe` is a `Just`, a succeeding `Task` is returned with the wrapped value, otherwise a failing `Task` is returned with the given error value. It has a curried and non-curried form.
 
 ```ts
 import { toTask } from '@execonline-inc/maybe-adapter';
@@ -26,9 +26,9 @@ import { nothing } from 'maybeasy';
 toTask<string, number>('an error message')(nothing());
 ```
 
-### `fromBool`
+### `fromBool`, `when`
 
-This function has a curried and non-curried form. It wraps a given value in a `Maybe` depending on either the given boolean value or boolean return value of the given function.
+This function wraps a given value in a `Maybe` depending on either the given boolean value or boolean return value of the given function. It has a curried and non-curried form.
 
 ```ts
 import { fromBool } from '@execonline-inc/maybe-adapter';
@@ -36,4 +36,17 @@ import { fromBool } from '@execonline-inc/maybe-adapter';
 fromBool(true)(123);
 fromBool((): boolean => true)(123);
 // Just<123>
+```
+
+### `toValues`
+
+This function takes an array of `Maybe<T>` and returns an array of `T` from the `Just` entries.
+
+```ts
+import { fromBool, toValues } from '@execonline-inc/maybe-adapter';
+import { just, nothing } from 'maybeasy';
+
+const list: ReadonlyArray<Maybe<number>> = [1, 2, 3, 4, 5].map(n => fromBool(n % 2 === 1, n));
+const result: ReadonlyArray<number> = toValues(list);
+// [1, 3, 5]
 ```

--- a/packages/maybe-adapter/src/maybe-adapter.ts
+++ b/packages/maybe-adapter/src/maybe-adapter.ts
@@ -34,3 +34,6 @@ export function when<T>(predicate: PredicateParam<T>, result?: T) {
 }
 
 export const fromBool = when;
+
+export const toValues = <T>(arr: ReadonlyArray<Maybe<T>>): ReadonlyArray<T> =>
+  arr.reduce<T[]>((vs, m) => m.map(v => [...vs, v]).getOrElseValue(vs), []);


### PR DESCRIPTION
Adds a function for when a list of conditional, independent values need to be reduced to the list of only present values from that list. An example use case is when compiling a list of separate class names for an HTML element.

Open to name suggestions.

Also updates the readme for the package.