### PR TITLE
Create a simple README with local dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/)
+
+# `CooperTS`
+
+Elm-inspired functional-programming tools in Typescript.
+
+Compilers are great. Let the compiler do the work.
+
+## Packages
+
+Most CooperTS packages are utility packages that build on primitive functional types from [`festive-possum`](https://github.com/kofno/festive-possum), such as `Maybe`, `Task`, `Result`, and `Decoder` types.
+
+- [`collections`](https://github.com/execonline-inc/CooperTS/tree/master/packages/collections) - Provides functions to work with lists in various ways
+- [`decoders`](https://github.com/execonline-inc/CooperTS/tree/master/packages/decoders) - Provides useful utility decoder implementations (see `jsonous`)
+- [`dom`](https://github.com/execonline-inc/CooperTS/tree/master/packages/dom) - Manipulate the HTML dom using Tasks (see `taskarian`)
+- [`environment`](https://github.com/execonline-inc/CooperTS/tree/master/packages/environment) - Provides functions to read from the execution environment
+- [`logging`](https://github.com/execonline-inc/CooperTS/tree/master/packages/logging) - Provides a few logging functions and also exports [`Honeybadger`](https://www.honeybadger.io/)
+- [`maybe-adapter`](https://github.com/execonline-inc/CooperTS/tree/master/packages/maybe-adapter) - Provides functions to convert to/from `Maybe` types (see `maybeasy`)
+- [`numbers`](https://github.com/execonline-inc/CooperTS/tree/master/packages/numbers) - Parse strings into numbers
+- [`url`](https://github.com/execonline-inc/CooperTS/tree/master/packages/url) - Provides functions to validate URLs
+
+Other CooperTS packages provide types & patterns for developers to conform to known good standards.
+
+- [`appy`](https://github.com/execonline-inc/CooperTS/tree/master/packages/appy) - Provides functions to interface with HATEOAS API endpoints
+- [`resource`](https://github.com/execonline-inc/CooperTS/tree/master/packages/resource) - Provides types and functions for dealing with HATEOAS REST resources
+- [`translations`](https://github.com/execonline-inc/CooperTS/tree/master/packages/translations) - Provides support for typed translation keys and typed React-based translation interpolation using the [i18next](https://www.i18next.com/) library with a custom adapter
+- [`time`](https://github.com/execonline-inc/CooperTS/tree/master/packages/time) - Provides interfaces and functions for dealing with time durations
+- [`time-distance`](https://github.com/execonline-inc/CooperTS/tree/master/packages/time-distance) - Provides interfaces and functions for dealing with distances between dates
+
+
+See also the lower-level packages at [`festive-possum`](https://github.com/kofno/festive-possum), especially:
+
+- [`ajaxian`](https://github.com/kofno/festive-possum/tree/main/packages/ajaxian) - A wrapper around `XMLHttpRequest` that borrows heavily from Elm
+- [`jsonous`](https://github.com/kofno/festive-possum/tree/main/packages/jsonous) - Use Elm-inspired `Decoder` functions to verify JSON objects match expected types
+- [`maybeasy`](https://github.com/kofno/festive-possum/tree/main/packages/maybeasy) - Use a `Maybe` to represent possibly-nullish values
+- [`nonempty-list`](https://github.com/kofno/festive-possum/tree/main/packages/nonempty-list) - A list-like type that is guaranteed to never be empty
+- [`piper`](https://github.com/kofno/festive-possum/tree/main/packages/piper) - Functional composition in Typescript
+- [`resulty`](https://github.com/kofno/festive-possum/tree/main/packages/resulty) - Defines `Result`, a disjunction implementation in Typescript
+- [`taskarian`](https://github.com/kofno/festive-possum/tree/main/packages/taskarian) - Defines `Task`, a Future implementation in Typescript; like Promises, but lazy
+
+## Local Development
+
+```bash
+# Clone the repo
+git clone https://github.com/execonline-inc/CooperTS.git
+cd CooperTS
+
+# Install dependencies
+yarn run bootstrap
+```

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "root",
   "private": true,
   "scripts": {
+    "bootstrap": "yarn install && lerna bootstrap",
     "tsc": "lerna run tsc",
     "publish": "lerna run tsc && lerna publish"
   },

--- a/packages/appy/yarn.lock
+++ b/packages/appy/yarn.lock
@@ -2,86 +2,6 @@
 # yarn lockfile v1
 
 
-"@execonline-inc/collections@^9.1.0":
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/collections/-/collections-9.1.0.tgz#fc319115a592044335fe6fe187d6d8a01d73d97c"
-  integrity sha512-SjLpNCA3uN5GiVBgzE5MpC68ir9Mzv4Zc71JeWhP53cq7dmxzCvbsWRHxb+pmpYt3oP0EDFsBVqkYNHJBmfyOA==
-  dependencies:
-    "@execonline-inc/maybe-adapter" "^4.2.0"
-    "@kofno/piper" "^3.0.0"
-    ajaxian "^4.0.0"
-    jsonous "^7.0.0"
-    logging "^3.3.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-"@execonline-inc/decoders@^6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/decoders/-/decoders-6.2.0.tgz#6734a2744428d2e3754d6ce05e2f8c0d5fc5c007"
-  integrity sha512-19DeTzHcSwPLKymqD+74cuYz/wNb2uGQ9IbKkjzfcBYumF3YTWwhwuPw2CS+hpJc9m6r940XfnRcn5GRxzTCug==
-  dependencies:
-    "@execonline-inc/time" "^5.0.0"
-    js-base64 "^3.7.2"
-    jsonous "^7.0.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-
-"@execonline-inc/environment@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/environment/-/environment-5.2.0.tgz#64673842198a9f97da6c2e2e54481f9de5e465d8"
-  integrity sha512-LrTu703ZqER+ccm/1Ck2bklsNkSO7XTjB1kQRbdhxw/HCCoJKwWZ/h1vilzNp6NMFw8ExhM10Lw2dU4mMyf9Qg==
-  dependencies:
-    "@kofno/piper" "^3.0.0"
-    ajaxian "^4.0.0"
-    honeybadger-js "^2.0.0"
-    jsonous "^7.0.0"
-    logging "^3.2.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-"@execonline-inc/maybe-adapter@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/maybe-adapter/-/maybe-adapter-4.2.0.tgz#0bff6a8cfb4a6db673f3aef13d1efc82f57f8f6e"
-  integrity sha512-6fve6R8g5RiNlHH//yYFxjcpZXn1JVa53g4Dfe2WFqLuxUJy1bKcDmgx3ppUZqhMvCjnsH4xb1IZNt6OA9GN/Q==
-  dependencies:
-    "@kofno/piper" "^3.0.0"
-    ajaxian "^4.0.0"
-    jsonous "^7.0.0"
-    logging "^3.2.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-"@execonline-inc/resource@^6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/resource/-/resource-6.11.0.tgz#f1bcbefc02e8fac3792cdfef149741ea4d98c8f6"
-  integrity sha512-CVi11eqYOEeMSU669XoOjnNROchYErUD/a+AYXzjfSrHTEfRDagxxBVN/Ji/uQoDUTZy+ghR0tz9ryqTV/QRKQ==
-  dependencies:
-    "@execonline-inc/collections" "^9.1.0"
-    "@execonline-inc/decoders" "^6.2.0"
-    "@execonline-inc/environment" "^5.2.0"
-    "@execonline-inc/maybe-adapter" "^4.2.0"
-    "@kofno/piper" "^3.0.0"
-    ajaxian "^4.0.0"
-    jsonous "^7.0.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-"@execonline-inc/time@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/time/-/time-5.0.0.tgz#b9f09d98f3de2af36b1acef39fd079fde056e8dc"
-  integrity sha512-HWnsBA80ceazdUTLHuk1n7ZHLDIPfeJY7tvdviVyoGSnFvPW0P/yACRaIGYxzeMpF+5sVdCExTLUstIohySVLg==
-  dependencies:
-    resulty "^5.0.0"
-
-"@kofno/piper@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@kofno/piper/-/piper-3.0.0.tgz#0897d8ddf701f171dddb1765e020f2dbb90ba2f1"
-  integrity sha512-fIqI7m9E6QWimpcNhayQdKg8eNi4c3+pVtDdu6jEJeipJKS95d17bpz7mJHAKnNY7YP6Z+ra2Ol54fqKAY7AAw==
-
 "@kofno/piper@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@kofno/piper/-/piper-4.3.0.tgz#001a8f81ec606df3c5d84edf59bff67042b4ea26"
@@ -92,14 +12,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
   integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
-ajaxian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ajaxian/-/ajaxian-4.0.0.tgz#555f347248015cce616531463c586d765139d5cb"
-  integrity sha512-7GVGgXycw13In2cuW8h4A7rmKbICbiH8C3m8j30PrOXLv8sr67ctAL7FyuD+AqJUvBSutfLtmV+HkTEl077fjg==
-  dependencies:
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
 ajaxian@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/ajaxian/-/ajaxian-4.4.0.tgz#a87344952a91c2ad78467c9907b2436bb6849a23"
@@ -108,79 +20,10 @@ ajaxian@^4.4.0:
     resulty "^5.0.0"
     taskarian "^5.1.0"
 
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
-
-ansi-styles@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
-  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
-  dependencies:
-    color-convert "^2.0.1"
-
-chalk@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-color-convert@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
-  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
-  dependencies:
-    color-name "~1.1.4"
-
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 date-fns@^2.16.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
   integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
-
-debug@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
-
-esutils@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
-  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
-
-has-flag@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
-  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
-honeybadger-js@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/honeybadger-js/-/honeybadger-js-2.3.0.tgz#040200066d60a8c1eca036e9f8568f9cff8b8d55"
-  integrity sha512-Tq1jPNumPe/l5RRDPDi+KNGULoaJQ9BSVZC+TEZOlPUzJx3AUn5ESb2NkCd7oSx/J221/aWUfz2/JrltHldx7A==
-
-js-base64@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.2.tgz#816d11d81a8aff241603d19ce5761e13e41d7745"
-  integrity sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==
-
-jsonous@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/jsonous/-/jsonous-7.0.0.tgz#1f2e5c280e6b8b6323d394afaccd2836d69df5f9"
-  integrity sha512-G7sa82OluhBZio6N4mLNEjNy5nOetsfETWWIYBIamobJdTex9EPo58Wl38lw4VSed0Ful+PfVTEEyb39vJorxw==
-  dependencies:
-    date-fns "^2.16.1"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    weakset "^1.0.0"
 
 jsonous@^7.3.0:
   version "7.3.0"
@@ -192,32 +35,10 @@ jsonous@^7.3.0:
     resulty "^5.0.0"
     weakset "^1.0.0"
 
-logging@^3.2.0, logging@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/logging/-/logging-3.3.0.tgz#5743f9154f790308c5d6f2e28196dd0259fcf0ad"
-  integrity sha512-Hnmu3KlGTbXMVS7ONjBpnjjiF9cBlK5qsmj77sOcqRkNpvO9ouUGPKe2PmBCWWYpKAbxb96b08cYEv4hiBk3lQ==
-  dependencies:
-    chalk "^4.1.0"
-    debug "^4.3.1"
-    nicely-format "^1.1.0"
-
 maybeasy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/maybeasy/-/maybeasy-3.0.0.tgz#732c244da190c742de99aa682e6f86a66152bbcc"
   integrity sha512-hMjmt0Kmfp2PdG9knKi6eUdp4513hkDib99EKqMK5tu1mn+t4Hih/pbJ4g5Kf3+f+c6GV6tBinZqtTtcnubm/g==
-
-ms@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-nicely-format@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nicely-format/-/nicely-format-1.1.0.tgz#6c3513d1f38077d65ed9721e716a8e1917ba27b6"
-  integrity sha1-bDUT0fOAd9Ze2XIecWqOGRe6J7Y=
-  dependencies:
-    ansi-styles "^2.2.1"
-    esutils "^2.0.2"
 
 resulty@^4.0.0:
   version "4.0.0"
@@ -228,20 +49,6 @@ resulty@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resulty/-/resulty-5.0.0.tgz#962fec061caaade8d600d39d88db370c4f4a9a9a"
   integrity sha512-K4E8JWqVqjCimjfdM/QyQWLs8xwdhJGVsVy2T6hvU9ihTEaEL72/eI/8wtVP7ddM+DKD2dNnNxLwthoX0RZrow==
-
-supports-color@^7.1.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
-  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
-  dependencies:
-    has-flag "^4.0.0"
-
-taskarian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-4.0.0.tgz#c82484b7b135629f07c18c689f99142c466894dd"
-  integrity sha512-C0cDkBYMpG6jXDUhdTxYL0ckXhRUVZddukexD+rrXamYIZy8k3DJ0vmNa49CrXiyLrcIDMoz1yJd6jFd2Lifcg==
-  dependencies:
-    resulty "^4.0.0"
 
 taskarian@^5.1.0:
   version "5.1.0"

--- a/packages/collections/yarn.lock
+++ b/packages/collections/yarn.lock
@@ -2,24 +2,6 @@
 # yarn lockfile v1
 
 
-"@execonline-inc/maybe-adapter@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/maybe-adapter/-/maybe-adapter-4.2.0.tgz#0bff6a8cfb4a6db673f3aef13d1efc82f57f8f6e"
-  integrity sha512-6fve6R8g5RiNlHH//yYFxjcpZXn1JVa53g4Dfe2WFqLuxUJy1bKcDmgx3ppUZqhMvCjnsH4xb1IZNt6OA9GN/Q==
-  dependencies:
-    "@kofno/piper" "^3.0.0"
-    ajaxian "^4.0.0"
-    jsonous "^7.0.0"
-    logging "^3.2.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-"@kofno/piper@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@kofno/piper/-/piper-3.0.0.tgz#0897d8ddf701f171dddb1765e020f2dbb90ba2f1"
-  integrity sha512-fIqI7m9E6QWimpcNhayQdKg8eNi4c3+pVtDdu6jEJeipJKS95d17bpz7mJHAKnNY7YP6Z+ra2Ol54fqKAY7AAw==
-
 "@kofno/piper@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@kofno/piper/-/piper-4.3.0.tgz#001a8f81ec606df3c5d84edf59bff67042b4ea26"
@@ -30,14 +12,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
   integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
-ajaxian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ajaxian/-/ajaxian-4.0.0.tgz#555f347248015cce616531463c586d765139d5cb"
-  integrity sha512-7GVGgXycw13In2cuW8h4A7rmKbICbiH8C3m8j30PrOXLv8sr67ctAL7FyuD+AqJUvBSutfLtmV+HkTEl077fjg==
-  dependencies:
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
 ajaxian@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/ajaxian/-/ajaxian-4.4.0.tgz#a87344952a91c2ad78467c9907b2436bb6849a23"
@@ -45,11 +19,6 @@ ajaxian@^4.4.0:
   dependencies:
     resulty "^5.0.0"
     taskarian "^5.1.0"
-
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -62,17 +31,6 @@ ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
-
-chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
-  dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
 
 chalk@^4.1.0:
   version "4.1.1"
@@ -99,13 +57,6 @@ date-fns@^2.16.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
   integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
 
-debug@^2.6.1:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
 debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
@@ -113,37 +64,15 @@ debug@^4.3.1:
   dependencies:
     ms "2.1.2"
 
-escape-string-regexp@^1.0.2:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-has-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
-  dependencies:
-    ansi-regex "^2.0.0"
-
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
-jsonous@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/jsonous/-/jsonous-7.0.0.tgz#1f2e5c280e6b8b6323d394afaccd2836d69df5f9"
-  integrity sha512-G7sa82OluhBZio6N4mLNEjNy5nOetsfETWWIYBIamobJdTex9EPo58Wl38lw4VSed0Ful+PfVTEEyb39vJorxw==
-  dependencies:
-    date-fns "^2.16.1"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    weakset "^1.0.0"
 
 jsonous@^7.3.0:
   version "7.3.0"
@@ -154,15 +83,6 @@ jsonous@^7.3.0:
     maybeasy "^3.0.0"
     resulty "^5.0.0"
     weakset "^1.0.0"
-
-logging@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/logging/-/logging-3.2.0.tgz#e35cd05e1ef23ef575d4e5b502605f904e197c6c"
-  integrity sha1-41zQXh7yPvV11OW1AmBfkE4ZfGw=
-  dependencies:
-    chalk "^1.1.3"
-    debug "^2.6.1"
-    nicely-format "^1.1.0"
 
 logging@^3.3.0:
   version "3.3.0"
@@ -177,11 +97,6 @@ maybeasy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/maybeasy/-/maybeasy-3.0.0.tgz#732c244da190c742de99aa682e6f86a66152bbcc"
   integrity sha512-hMjmt0Kmfp2PdG9knKi6eUdp4513hkDib99EKqMK5tu1mn+t4Hih/pbJ4g5Kf3+f+c6GV6tBinZqtTtcnubm/g==
-
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 ms@2.1.2:
   version "2.1.2"
@@ -206,31 +121,12 @@ resulty@^5.0.0:
   resolved "https://registry.yarnpkg.com/resulty/-/resulty-5.0.0.tgz#962fec061caaade8d600d39d88db370c4f4a9a9a"
   integrity sha512-K4E8JWqVqjCimjfdM/QyQWLs8xwdhJGVsVy2T6hvU9ihTEaEL72/eI/8wtVP7ddM+DKD2dNnNxLwthoX0RZrow==
 
-strip-ansi@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-  dependencies:
-    ansi-regex "^2.0.0"
-
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
-
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
-
-taskarian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-4.0.0.tgz#c82484b7b135629f07c18c689f99142c466894dd"
-  integrity sha512-C0cDkBYMpG6jXDUhdTxYL0ckXhRUVZddukexD+rrXamYIZy8k3DJ0vmNa49CrXiyLrcIDMoz1yJd6jFd2Lifcg==
-  dependencies:
-    resulty "^4.0.0"
 
 taskarian@^5.1.0:
   version "5.1.0"

--- a/packages/decoders/yarn.lock
+++ b/packages/decoders/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@execonline-inc/time@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/time/-/time-5.0.0.tgz#b9f09d98f3de2af36b1acef39fd079fde056e8dc"
-  integrity sha512-HWnsBA80ceazdUTLHuk1n7ZHLDIPfeJY7tvdviVyoGSnFvPW0P/yACRaIGYxzeMpF+5sVdCExTLUstIohySVLg==
-  dependencies:
-    resulty "^5.0.0"
-
 "@types/node@^17.0.23":
   version "17.0.23"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"

--- a/packages/logging/yarn.lock
+++ b/packages/logging/yarn.lock
@@ -2,37 +2,10 @@
 # yarn lockfile v1
 
 
-"@execonline-inc/environment@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/environment/-/environment-5.2.0.tgz#64673842198a9f97da6c2e2e54481f9de5e465d8"
-  integrity sha512-LrTu703ZqER+ccm/1Ck2bklsNkSO7XTjB1kQRbdhxw/HCCoJKwWZ/h1vilzNp6NMFw8ExhM10Lw2dU4mMyf9Qg==
-  dependencies:
-    "@kofno/piper" "^3.0.0"
-    ajaxian "^4.0.0"
-    honeybadger-js "^2.0.0"
-    jsonous "^7.0.0"
-    logging "^3.2.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-"@kofno/piper@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@kofno/piper/-/piper-3.0.0.tgz#0897d8ddf701f171dddb1765e020f2dbb90ba2f1"
-  integrity sha512-fIqI7m9E6QWimpcNhayQdKg8eNi4c3+pVtDdu6jEJeipJKS95d17bpz7mJHAKnNY7YP6Z+ra2Ol54fqKAY7AAw==
-
 "@types/node@^17.0.23":
   version "17.0.23"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
   integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
-
-ajaxian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ajaxian/-/ajaxian-4.0.0.tgz#555f347248015cce616531463c586d765139d5cb"
-  integrity sha512-7GVGgXycw13In2cuW8h4A7rmKbICbiH8C3m8j30PrOXLv8sr67ctAL7FyuD+AqJUvBSutfLtmV+HkTEl077fjg==
-  dependencies:
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -54,11 +27,6 @@ chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
-
-date-fns@^2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
-  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
 debug@^2.6.1:
   version "2.6.9"
@@ -84,21 +52,6 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-honeybadger-js@^2.0.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/honeybadger-js/-/honeybadger-js-2.2.2.tgz#53b345abcbb39740cd2229683f36959316f947bc"
-  integrity sha512-dRdTngkp5oqZ7076DDDMle/XHvMuPDXrh35tFkAGJIUabWMj71IODRm9ggLenDF2XxfB6FjrK4Ry5YixZTM4Ug==
-
-jsonous@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/jsonous/-/jsonous-7.0.0.tgz#1f2e5c280e6b8b6323d394afaccd2836d69df5f9"
-  integrity sha512-G7sa82OluhBZio6N4mLNEjNy5nOetsfETWWIYBIamobJdTex9EPo58Wl38lw4VSed0Ful+PfVTEEyb39vJorxw==
-  dependencies:
-    date-fns "^2.16.1"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    weakset "^1.0.0"
-
 logging@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/logging/-/logging-3.2.0.tgz#e35cd05e1ef23ef575d4e5b502605f904e197c6c"
@@ -107,11 +60,6 @@ logging@^3.2.0:
     chalk "^1.1.3"
     debug "^2.6.1"
     nicely-format "^1.1.0"
-
-maybeasy@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/maybeasy/-/maybeasy-3.0.0.tgz#732c244da190c742de99aa682e6f86a66152bbcc"
-  integrity sha512-hMjmt0Kmfp2PdG9knKi6eUdp4513hkDib99EKqMK5tu1mn+t4Hih/pbJ4g5Kf3+f+c6GV6tBinZqtTtcnubm/g==
 
 ms@2.0.0:
   version "2.0.0"
@@ -126,11 +74,6 @@ nicely-format@^1.1.0:
     ansi-styles "^2.2.1"
     esutils "^2.0.2"
 
-resulty@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resulty/-/resulty-4.0.0.tgz#fbd6470fde712a88b7c983394c7486da290ea6e2"
-  integrity sha512-toajg6lqdp9tmV0ohsTxWiwoaWJd2WiuH7vOx+BJtj1Bs9+XoGa+0Zu8yRNV02gS5DphnrdnRG4Xjr7vl+eP8g==
-
 strip-ansi@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -143,19 +86,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-taskarian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-4.0.0.tgz#c82484b7b135629f07c18c689f99142c466894dd"
-  integrity sha512-C0cDkBYMpG6jXDUhdTxYL0ckXhRUVZddukexD+rrXamYIZy8k3DJ0vmNa49CrXiyLrcIDMoz1yJd6jFd2Lifcg==
-  dependencies:
-    resulty "^4.0.0"
-
 typescript@^4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
   integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
-
-weakset@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/weakset/-/weakset-1.0.0.tgz#7d525ebb93b24d38e6d0a19b0f3e14f099a3b270"
-  integrity sha1-fVJeu5OyTTjm0KGbDz4U8JmjsnA=

--- a/packages/numbers/yarn.lock
+++ b/packages/numbers/yarn.lock
@@ -2,24 +2,6 @@
 # yarn lockfile v1
 
 
-"@execonline-inc/maybe-adapter@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/maybe-adapter/-/maybe-adapter-4.2.0.tgz#0bff6a8cfb4a6db673f3aef13d1efc82f57f8f6e"
-  integrity sha512-6fve6R8g5RiNlHH//yYFxjcpZXn1JVa53g4Dfe2WFqLuxUJy1bKcDmgx3ppUZqhMvCjnsH4xb1IZNt6OA9GN/Q==
-  dependencies:
-    "@kofno/piper" "^3.0.0"
-    ajaxian "^4.0.0"
-    jsonous "^7.0.0"
-    logging "^3.2.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-"@kofno/piper@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@kofno/piper/-/piper-3.0.0.tgz#0897d8ddf701f171dddb1765e020f2dbb90ba2f1"
-  integrity sha512-fIqI7m9E6QWimpcNhayQdKg8eNi4c3+pVtDdu6jEJeipJKS95d17bpz7mJHAKnNY7YP6Z+ra2Ol54fqKAY7AAw==
-
 "@kofno/piper@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@kofno/piper/-/piper-4.3.0.tgz#001a8f81ec606df3c5d84edf59bff67042b4ea26"
@@ -30,129 +12,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
   integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
-ajaxian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ajaxian/-/ajaxian-4.0.0.tgz#555f347248015cce616531463c586d765139d5cb"
-  integrity sha512-7GVGgXycw13In2cuW8h4A7rmKbICbiH8C3m8j30PrOXLv8sr67ctAL7FyuD+AqJUvBSutfLtmV+HkTEl077fjg==
-  dependencies:
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
-
-chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
-  dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
-
-date-fns@^2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
-  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
-
-debug@^2.6.1:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
-escape-string-regexp@^1.0.2:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
-esutils@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
-  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
-
-has-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
-  dependencies:
-    ansi-regex "^2.0.0"
-
-jsonous@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/jsonous/-/jsonous-7.0.0.tgz#1f2e5c280e6b8b6323d394afaccd2836d69df5f9"
-  integrity sha512-G7sa82OluhBZio6N4mLNEjNy5nOetsfETWWIYBIamobJdTex9EPo58Wl38lw4VSed0Ful+PfVTEEyb39vJorxw==
-  dependencies:
-    date-fns "^2.16.1"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    weakset "^1.0.0"
-
-logging@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/logging/-/logging-3.2.0.tgz#e35cd05e1ef23ef575d4e5b502605f904e197c6c"
-  integrity sha1-41zQXh7yPvV11OW1AmBfkE4ZfGw=
-  dependencies:
-    chalk "^1.1.3"
-    debug "^2.6.1"
-    nicely-format "^1.1.0"
-
 maybeasy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/maybeasy/-/maybeasy-3.0.0.tgz#732c244da190c742de99aa682e6f86a66152bbcc"
   integrity sha512-hMjmt0Kmfp2PdG9knKi6eUdp4513hkDib99EKqMK5tu1mn+t4Hih/pbJ4g5Kf3+f+c6GV6tBinZqtTtcnubm/g==
 
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
-
-nicely-format@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nicely-format/-/nicely-format-1.1.0.tgz#6c3513d1f38077d65ed9721e716a8e1917ba27b6"
-  integrity sha1-bDUT0fOAd9Ze2XIecWqOGRe6J7Y=
-  dependencies:
-    ansi-styles "^2.2.1"
-    esutils "^2.0.2"
-
-resulty@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resulty/-/resulty-4.0.0.tgz#fbd6470fde712a88b7c983394c7486da290ea6e2"
-  integrity sha512-toajg6lqdp9tmV0ohsTxWiwoaWJd2WiuH7vOx+BJtj1Bs9+XoGa+0Zu8yRNV02gS5DphnrdnRG4Xjr7vl+eP8g==
-
 resulty@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resulty/-/resulty-5.0.0.tgz#962fec061caaade8d600d39d88db370c4f4a9a9a"
   integrity sha512-K4E8JWqVqjCimjfdM/QyQWLs8xwdhJGVsVy2T6hvU9ihTEaEL72/eI/8wtVP7ddM+DKD2dNnNxLwthoX0RZrow==
-
-strip-ansi@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-  dependencies:
-    ansi-regex "^2.0.0"
-
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
-
-taskarian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-4.0.0.tgz#c82484b7b135629f07c18c689f99142c466894dd"
-  integrity sha512-C0cDkBYMpG6jXDUhdTxYL0ckXhRUVZddukexD+rrXamYIZy8k3DJ0vmNa49CrXiyLrcIDMoz1yJd6jFd2Lifcg==
-  dependencies:
-    resulty "^4.0.0"
 
 taskarian@^5.1.0:
   version "5.1.0"
@@ -166,8 +34,3 @@ typescript@^4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
   integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
-
-weakset@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/weakset/-/weakset-1.0.0.tgz#7d525ebb93b24d38e6d0a19b0f3e14f099a3b270"
-  integrity sha1-fVJeu5OyTTjm0KGbDz4U8JmjsnA=

--- a/packages/resource/yarn.lock
+++ b/packages/resource/yarn.lock
@@ -2,70 +2,6 @@
 # yarn lockfile v1
 
 
-"@execonline-inc/collections@^9.1.0":
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/collections/-/collections-9.1.0.tgz#fc319115a592044335fe6fe187d6d8a01d73d97c"
-  integrity sha512-SjLpNCA3uN5GiVBgzE5MpC68ir9Mzv4Zc71JeWhP53cq7dmxzCvbsWRHxb+pmpYt3oP0EDFsBVqkYNHJBmfyOA==
-  dependencies:
-    "@execonline-inc/maybe-adapter" "^4.2.0"
-    "@kofno/piper" "^3.0.0"
-    ajaxian "^4.0.0"
-    jsonous "^7.0.0"
-    logging "^3.3.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-"@execonline-inc/decoders@^6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/decoders/-/decoders-6.2.0.tgz#6734a2744428d2e3754d6ce05e2f8c0d5fc5c007"
-  integrity sha512-19DeTzHcSwPLKymqD+74cuYz/wNb2uGQ9IbKkjzfcBYumF3YTWwhwuPw2CS+hpJc9m6r940XfnRcn5GRxzTCug==
-  dependencies:
-    "@execonline-inc/time" "^5.0.0"
-    js-base64 "^3.7.2"
-    jsonous "^7.0.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-
-"@execonline-inc/environment@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/environment/-/environment-5.2.0.tgz#64673842198a9f97da6c2e2e54481f9de5e465d8"
-  integrity sha512-LrTu703ZqER+ccm/1Ck2bklsNkSO7XTjB1kQRbdhxw/HCCoJKwWZ/h1vilzNp6NMFw8ExhM10Lw2dU4mMyf9Qg==
-  dependencies:
-    "@kofno/piper" "^3.0.0"
-    ajaxian "^4.0.0"
-    honeybadger-js "^2.0.0"
-    jsonous "^7.0.0"
-    logging "^3.2.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-"@execonline-inc/maybe-adapter@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/maybe-adapter/-/maybe-adapter-4.2.0.tgz#0bff6a8cfb4a6db673f3aef13d1efc82f57f8f6e"
-  integrity sha512-6fve6R8g5RiNlHH//yYFxjcpZXn1JVa53g4Dfe2WFqLuxUJy1bKcDmgx3ppUZqhMvCjnsH4xb1IZNt6OA9GN/Q==
-  dependencies:
-    "@kofno/piper" "^3.0.0"
-    ajaxian "^4.0.0"
-    jsonous "^7.0.0"
-    logging "^3.2.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-"@execonline-inc/time@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/time/-/time-5.0.0.tgz#b9f09d98f3de2af36b1acef39fd079fde056e8dc"
-  integrity sha512-HWnsBA80ceazdUTLHuk1n7ZHLDIPfeJY7tvdviVyoGSnFvPW0P/yACRaIGYxzeMpF+5sVdCExTLUstIohySVLg==
-  dependencies:
-    resulty "^5.0.0"
-
-"@kofno/piper@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@kofno/piper/-/piper-3.0.0.tgz#0897d8ddf701f171dddb1765e020f2dbb90ba2f1"
-  integrity sha512-fIqI7m9E6QWimpcNhayQdKg8eNi4c3+pVtDdu6jEJeipJKS95d17bpz7mJHAKnNY7YP6Z+ra2Ol54fqKAY7AAw==
-
 "@kofno/piper@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@kofno/piper/-/piper-4.3.0.tgz#001a8f81ec606df3c5d84edf59bff67042b4ea26"
@@ -76,14 +12,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
   integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
-ajaxian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ajaxian/-/ajaxian-4.0.0.tgz#555f347248015cce616531463c586d765139d5cb"
-  integrity sha512-7GVGgXycw13In2cuW8h4A7rmKbICbiH8C3m8j30PrOXLv8sr67ctAL7FyuD+AqJUvBSutfLtmV+HkTEl077fjg==
-  dependencies:
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
 ajaxian@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/ajaxian/-/ajaxian-4.4.0.tgz#a87344952a91c2ad78467c9907b2436bb6849a23"
@@ -92,114 +20,10 @@ ajaxian@^4.4.0:
     resulty "^5.0.0"
     taskarian "^5.1.0"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
-
-ansi-styles@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
-  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
-  dependencies:
-    color-convert "^2.0.1"
-
-chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
-  dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
-
-chalk@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
-  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-color-convert@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
-  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
-  dependencies:
-    color-name "~1.1.4"
-
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 date-fns@^2.16.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
   integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
-
-debug@^2.6.1:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
-debug@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
-
-escape-string-regexp@^1.0.2:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
-esutils@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
-  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
-
-has-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
-  dependencies:
-    ansi-regex "^2.0.0"
-
-has-flag@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
-  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
-honeybadger-js@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/honeybadger-js/-/honeybadger-js-2.3.0.tgz#040200066d60a8c1eca036e9f8568f9cff8b8d55"
-  integrity sha512-Tq1jPNumPe/l5RRDPDi+KNGULoaJQ9BSVZC+TEZOlPUzJx3AUn5ESb2NkCd7oSx/J221/aWUfz2/JrltHldx7A==
-
-js-base64@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.2.tgz#816d11d81a8aff241603d19ce5761e13e41d7745"
-  integrity sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==
-
-jsonous@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/jsonous/-/jsonous-7.0.0.tgz#1f2e5c280e6b8b6323d394afaccd2836d69df5f9"
-  integrity sha512-G7sa82OluhBZio6N4mLNEjNy5nOetsfETWWIYBIamobJdTex9EPo58Wl38lw4VSed0Ful+PfVTEEyb39vJorxw==
-  dependencies:
-    date-fns "^2.16.1"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    weakset "^1.0.0"
 
 jsonous@^7.3.0:
   version "7.3.0"
@@ -211,82 +35,15 @@ jsonous@^7.3.0:
     resulty "^5.0.0"
     weakset "^1.0.0"
 
-logging@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/logging/-/logging-3.2.0.tgz#e35cd05e1ef23ef575d4e5b502605f904e197c6c"
-  integrity sha1-41zQXh7yPvV11OW1AmBfkE4ZfGw=
-  dependencies:
-    chalk "^1.1.3"
-    debug "^2.6.1"
-    nicely-format "^1.1.0"
-
-logging@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/logging/-/logging-3.3.0.tgz#5743f9154f790308c5d6f2e28196dd0259fcf0ad"
-  integrity sha512-Hnmu3KlGTbXMVS7ONjBpnjjiF9cBlK5qsmj77sOcqRkNpvO9ouUGPKe2PmBCWWYpKAbxb96b08cYEv4hiBk3lQ==
-  dependencies:
-    chalk "^4.1.0"
-    debug "^4.3.1"
-    nicely-format "^1.1.0"
-
 maybeasy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/maybeasy/-/maybeasy-3.0.0.tgz#732c244da190c742de99aa682e6f86a66152bbcc"
   integrity sha512-hMjmt0Kmfp2PdG9knKi6eUdp4513hkDib99EKqMK5tu1mn+t4Hih/pbJ4g5Kf3+f+c6GV6tBinZqtTtcnubm/g==
 
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
-
-ms@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-nicely-format@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nicely-format/-/nicely-format-1.1.0.tgz#6c3513d1f38077d65ed9721e716a8e1917ba27b6"
-  integrity sha1-bDUT0fOAd9Ze2XIecWqOGRe6J7Y=
-  dependencies:
-    ansi-styles "^2.2.1"
-    esutils "^2.0.2"
-
-resulty@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resulty/-/resulty-4.0.0.tgz#fbd6470fde712a88b7c983394c7486da290ea6e2"
-  integrity sha512-toajg6lqdp9tmV0ohsTxWiwoaWJd2WiuH7vOx+BJtj1Bs9+XoGa+0Zu8yRNV02gS5DphnrdnRG4Xjr7vl+eP8g==
-
 resulty@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resulty/-/resulty-5.0.0.tgz#962fec061caaade8d600d39d88db370c4f4a9a9a"
   integrity sha512-K4E8JWqVqjCimjfdM/QyQWLs8xwdhJGVsVy2T6hvU9ihTEaEL72/eI/8wtVP7ddM+DKD2dNnNxLwthoX0RZrow==
-
-strip-ansi@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-  dependencies:
-    ansi-regex "^2.0.0"
-
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
-
-supports-color@^7.1.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
-  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
-  dependencies:
-    has-flag "^4.0.0"
-
-taskarian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-4.0.0.tgz#c82484b7b135629f07c18c689f99142c466894dd"
-  integrity sha512-C0cDkBYMpG6jXDUhdTxYL0ckXhRUVZddukexD+rrXamYIZy8k3DJ0vmNa49CrXiyLrcIDMoz1yJd6jFd2Lifcg==
-  dependencies:
-    resulty "^4.0.0"
 
 taskarian@^5.1.0:
   version "5.1.0"

--- a/packages/time-distance/yarn.lock
+++ b/packages/time-distance/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@execonline-inc/time@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/time/-/time-5.0.0.tgz#b9f09d98f3de2af36b1acef39fd079fde056e8dc"
-  integrity sha512-HWnsBA80ceazdUTLHuk1n7ZHLDIPfeJY7tvdviVyoGSnFvPW0P/yACRaIGYxzeMpF+5sVdCExTLUstIohySVLg==
-  dependencies:
-    resulty "^5.0.0"
-
 "@types/node@^17.0.23":
   version "17.0.23"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"

--- a/packages/translations/yarn.lock
+++ b/packages/translations/yarn.lock
@@ -9,60 +9,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@execonline-inc/collections@^9.1.0":
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/collections/-/collections-9.1.0.tgz#fc319115a592044335fe6fe187d6d8a01d73d97c"
-  integrity sha512-SjLpNCA3uN5GiVBgzE5MpC68ir9Mzv4Zc71JeWhP53cq7dmxzCvbsWRHxb+pmpYt3oP0EDFsBVqkYNHJBmfyOA==
-  dependencies:
-    "@execonline-inc/maybe-adapter" "^4.2.0"
-    "@kofno/piper" "^3.0.0"
-    ajaxian "^4.0.0"
-    jsonous "^7.0.0"
-    logging "^3.3.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-"@execonline-inc/environment@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/environment/-/environment-5.2.0.tgz#64673842198a9f97da6c2e2e54481f9de5e465d8"
-  integrity sha512-LrTu703ZqER+ccm/1Ck2bklsNkSO7XTjB1kQRbdhxw/HCCoJKwWZ/h1vilzNp6NMFw8ExhM10Lw2dU4mMyf9Qg==
-  dependencies:
-    "@kofno/piper" "^3.0.0"
-    ajaxian "^4.0.0"
-    honeybadger-js "^2.0.0"
-    jsonous "^7.0.0"
-    logging "^3.2.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-"@execonline-inc/logging@^5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/logging/-/logging-5.3.0.tgz#b27c33aaacb8d17a34f0de6505143c394811c43a"
-  integrity sha512-NyYLTzPKoFy4wuWaExbxt52AFvv57QnY0+CdSdadWLQL06hw8Ohv/i68kBHvQ4/v3nWpPG6vVvPzanR13to3wA==
-  dependencies:
-    "@execonline-inc/environment" "^5.2.0"
-    logging "^3.2.0"
-
-"@execonline-inc/maybe-adapter@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@execonline-inc/maybe-adapter/-/maybe-adapter-4.2.0.tgz#0bff6a8cfb4a6db673f3aef13d1efc82f57f8f6e"
-  integrity sha512-6fve6R8g5RiNlHH//yYFxjcpZXn1JVa53g4Dfe2WFqLuxUJy1bKcDmgx3ppUZqhMvCjnsH4xb1IZNt6OA9GN/Q==
-  dependencies:
-    "@kofno/piper" "^3.0.0"
-    ajaxian "^4.0.0"
-    jsonous "^7.0.0"
-    logging "^3.2.0"
-    maybeasy "^3.0.0"
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-"@kofno/piper@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@kofno/piper/-/piper-3.0.0.tgz#0897d8ddf701f171dddb1765e020f2dbb90ba2f1"
-  integrity sha512-fIqI7m9E6QWimpcNhayQdKg8eNi4c3+pVtDdu6jEJeipJKS95d17bpz7mJHAKnNY7YP6Z+ra2Ol54fqKAY7AAw==
-
 "@kofno/piper@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@kofno/piper/-/piper-4.3.0.tgz#001a8f81ec606df3c5d84edf59bff67042b4ea26"
@@ -99,46 +45,6 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-ajaxian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ajaxian/-/ajaxian-4.0.0.tgz#555f347248015cce616531463c586d765139d5cb"
-  integrity sha512-7GVGgXycw13In2cuW8h4A7rmKbICbiH8C3m8j30PrOXLv8sr67ctAL7FyuD+AqJUvBSutfLtmV+HkTEl077fjg==
-  dependencies:
-    resulty "^4.0.0"
-    taskarian "^4.0.0"
-
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
-
-ansi-styles@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
-  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
-  dependencies:
-    color-convert "^2.0.1"
-
-chalk@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-color-convert@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
-  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
-  dependencies:
-    color-name "~1.1.4"
-
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 csstype@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
@@ -148,13 +54,6 @@ date-fns@^2.16.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
   integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
-
-debug@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
 
 dom-serializer@^0.2.1:
   version "0.2.2"
@@ -190,27 +89,12 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
   integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
-esutils@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
-  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
-
-has-flag@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
-  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
 hoist-non-react-statics@^3.0.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
   dependencies:
     react-is "^16.7.0"
-
-honeybadger-js@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/honeybadger-js/-/honeybadger-js-2.3.0.tgz#040200066d60a8c1eca036e9f8568f9cff8b8d55"
-  integrity sha512-Tq1jPNumPe/l5RRDPDi+KNGULoaJQ9BSVZC+TEZOlPUzJx3AUn5ESb2NkCd7oSx/J221/aWUfz2/JrltHldx7A==
 
 htmlparser2@^4.1.0:
   version "4.1.0"
@@ -232,15 +116,6 @@ jsonous@^7.0.0:
     resulty "^4.0.0"
     weakset "^1.0.0"
 
-logging@^3.2.0, logging@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/logging/-/logging-3.3.0.tgz#5743f9154f790308c5d6f2e28196dd0259fcf0ad"
-  integrity sha512-Hnmu3KlGTbXMVS7ONjBpnjjiF9cBlK5qsmj77sOcqRkNpvO9ouUGPKe2PmBCWWYpKAbxb96b08cYEv4hiBk3lQ==
-  dependencies:
-    chalk "^4.1.0"
-    debug "^4.3.1"
-    nicely-format "^1.1.0"
-
 maybeasy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/maybeasy/-/maybeasy-3.0.0.tgz#732c244da190c742de99aa682e6f86a66152bbcc"
@@ -258,19 +133,6 @@ mobx@^4.15.7:
   version "4.15.7"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-4.15.7.tgz#933281268c3b4658b6cf2526e872cf78ea48ab95"
   integrity sha512-X4uQvuf2zYKHVO5kRT5Utmr+J9fDnRgxWWnSqJ4oiccPTQU38YG+/O3nPmOhUy4jeHexl7XJJpWDBgEnEfp+8w==
-
-ms@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-nicely-format@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nicely-format/-/nicely-format-1.1.0.tgz#6c3513d1f38077d65ed9721e716a8e1917ba27b6"
-  integrity sha1-bDUT0fOAd9Ze2XIecWqOGRe6J7Y=
-  dependencies:
-    ansi-styles "^2.2.1"
-    esutils "^2.0.2"
 
 nonempty-list@^3.3.0:
   version "3.3.0"
@@ -304,20 +166,6 @@ resulty@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resulty/-/resulty-5.0.0.tgz#962fec061caaade8d600d39d88db370c4f4a9a9a"
   integrity sha512-K4E8JWqVqjCimjfdM/QyQWLs8xwdhJGVsVy2T6hvU9ihTEaEL72/eI/8wtVP7ddM+DKD2dNnNxLwthoX0RZrow==
-
-supports-color@^7.1.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
-  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
-  dependencies:
-    has-flag "^4.0.0"
-
-taskarian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-4.0.0.tgz#c82484b7b135629f07c18c689f99142c466894dd"
-  integrity sha512-C0cDkBYMpG6jXDUhdTxYL0ckXhRUVZddukexD+rrXamYIZy8k3DJ0vmNa49CrXiyLrcIDMoz1yJd6jFd2Lifcg==
-  dependencies:
-    resulty "^4.0.0"
 
 taskarian@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
When running the local dev instructions on a freshly-cloned repo there were a bunch of updates to `yarn.lock` files, so I included those. They seem to be correct.

See the rendered readme: https://github.com/execonline-inc/CooperTS/tree/add-simple-readme

We probably want more in a readme, but a list of packages & local dev instructions seemed like a good place to start. Are the instructions correct?