### PR TITLE
Add syntax highlighting to code in rendered md

### DIFF
--- a/docs/Types/guide.ts
+++ b/docs/Types/guide.ts
@@ -1,10 +1,18 @@
 import Decoder, { field, string, succeed } from 'jsonous';
 import { requireDecoderDuringBuild } from '../RequireDecoderDuringBuild';
 
+export interface SafeMarkdown {
+  content: string;
+}
+
+// Users of this method need to verify that the markdown content is from a
+// trusted source; otherwise we could be vulnerable to a XSS attack.
+export const unsafeMarkdownFromContent = (content: string): SafeMarkdown => ({ content });
+
 export interface Page {
   slug: string;
   frontmatter: Frontmatter;
-  content: string;
+  markdown: SafeMarkdown;
 }
 
 export interface Frontmatter {

--- a/docs/components/Markdown/index.tsx
+++ b/docs/components/Markdown/index.tsx
@@ -1,0 +1,52 @@
+import clsx from 'clsx';
+import hljs from 'highlight.js';
+import 'highlight.js/styles/a11y-dark.css';
+import { marked } from 'marked';
+import { observer } from 'mobx-react';
+import * as React from 'react';
+import { SafeMarkdown } from '../../Types/guide';
+
+interface Props {
+  markdown: SafeMarkdown;
+}
+
+const markdownToHtmlString = (markdown: SafeMarkdown): string =>
+  marked(markdown.content, {
+    highlight: function(code, lang) {
+      const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+      return hljs.highlight(code, { language }).value;
+    },
+  });
+
+const Markdown: React.FC<Props> = ({ markdown }) => (
+  <div
+    className={clsx(
+      'prose prose-slate w-full lg:max-w-none',
+      'prose-headings:scroll-mt-28',
+      'prose-headings:font-display prose-headings:font-normal',
+      'prose-lead:text-slate-500',
+      'prose-a:font-semibold prose-a:no-underline',
+      'prose-a:shadow-[var(--proseAShadow)]',
+      'hover:prose-a:[--tw-prose-underline-size:6px]',
+      'prose-pre:rounded-xl prose-pre:bg-slate-900 prose-pre:shadow-lg',
+      'prose-pre:p-3 md:prose-pre:p-5',
+      'prose-pre:text-xs md:prose-pre:text-sm lg:prose-pre:text-base',
+      'dark:prose-invert dark:text-slate-400',
+
+      'dark:[--tw-prose-background:theme(colors.slate.900)] dark:prose-lead:text-slate-400',
+      'dark:prose-a:text-sky-400',
+
+      'dark:prose-a:shadow-[var(--darkProseAShadow)]',
+      'dark:hover:prose-a:[--tw-prose-underline-size:6px]',
+      'dark:prose-pre:bg-slate-800/60 dark:prose-pre:shadow-none dark:prose-pre:ring-1',
+
+      'dark:prose-pre:ring-slate-300/10 dark:prose-hr:border-slate-800',
+      'lg:prose-headings:scroll-mt-[8.5rem]'
+    )}
+    dangerouslySetInnerHTML={{
+      __html: markdownToHtmlString(markdown),
+    }}
+  />
+);
+
+export default observer(Markdown);

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
     "focus-visible": "^5.2.0",
     "glob": "^8.0.3",
     "gray-matter": "^4.0.3",
+    "highlight.js": "^11.5.1",
     "jsonous": "^7.3.0",
     "marked": "^4.0.17",
     "next": "12.1.6",

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,10 +1,10 @@
-import Header from '../components/Header/Header';
 import clsx from 'clsx';
-import { Footer } from '../components/Footer/Footer';
 import type { AppProps } from 'next/app';
 import * as React from 'react';
-import '../styles/globals.css';
 import BreakPointDebug from '../components/BreakPointDebug/BreakPointDebug';
+import { Footer } from '../components/Footer/Footer';
+import Header from '../components/Header/Header';
+import '../styles/globals.css';
 
 const App: React.FC<AppProps> = ({ Component, pageProps }) => {
   return (

--- a/docs/pages/guide.tsx
+++ b/docs/pages/guide.tsx
@@ -1,7 +1,8 @@
+import clsx from 'clsx';
 import matter from 'gray-matter';
 import Link from 'next/link';
 import { getFilesFromPath, getMarkDownWithMeta } from '../lib';
-import { Page } from '../Types/guide';
+import { Page, requireFrontmatterDuringBuild, unsafeMarkdownFromContent } from '../Types/guide';
 
 interface Props {
   pages: Page[];
@@ -9,39 +10,42 @@ interface Props {
 
 const Guide: React.FC<Props> = ({ pages }) => {
   return (
-    <div className="not-prose relative lg:block lg:flex-none">
+    <div className={clsx('not-prose relative lg:block lg:flex-none')}>
       <div
-        className={`sticky top-[4.5rem] -ml-0.5 h-[calc(100vh-4.5rem)] 
-          overflow-y-auto py-16 pl-0.5`}
+        className={clsx(
+          'sticky top-[4.5rem] -ml-0.5 h-[calc(100vh-4.5rem)]',
+          'overflow-y-auto py-16 pl-0.5'
+        )}
       >
-        <nav className={`w-64 pr-8 text-base lg:text-sm xl:w-72 xl:pr-16`}>
-          <ul className="space-y-9">
+        <nav className={clsx('w-64 pr-8 text-base lg:text-sm xl:w-72 xl:pr-16')}>
+          <ul className={clsx('space-y-9')}>
             <li>
-              <h2
-                className={`font-display font-medium 
-                text-slate-900 dark:text-white`}
-              >
+              <h2 className={clsx('font-display font-medium text-slate-900 dark:text-white')}>
                 Guide
               </h2>
               <ul
-                className={`not-prose lg:border-slate-20 
-                mt-6 space-y-2 border-l-2 
-                border-slate-100 dark:border-slate-800 
-                lg:mt-4 lg:space-y-4`}
+                className={clsx(
+                  'not-prose lg:border-slate-20',
+                  'mt-6 space-y-2 border-l-2',
+                  'border-slate-100 dark:border-slate-800',
+                  'lg:mt-4 lg:space-y-4'
+                )}
               >
                 {pages.map(({ slug, frontmatter: { title } }) => (
-                  <li key={slug} className="relative">
+                  <li key={slug} className={clsx('relative')}>
                     <Link href={`/guide/${slug}`}>
                       <a
                         href="#"
-                        className={`block w-full pl-3.5 
-                        text-slate-500
-                        before:pointer-events-none before:absolute before:-left-1
-                        before:top-1/2 before:hidden before:h-1.5 before:w-1.5
-                        before:-translate-y-1/2 before:rounded-full
-                        before:bg-slate-300 hover:text-slate-600
-                        hover:before:block dark:text-slate-400
-                        dark:before:bg-slate-700 dark:hover:text-slate-300`}
+                        className={clsx(
+                          'block w-full pl-3.5',
+                          'text-slate-500',
+                          'before:pointer-events-none before:absolute before:-left-1',
+                          'before:top-1/2 before:hidden before:h-1.5 before:w-1.5',
+                          'before:-translate-y-1/2 before:rounded-full',
+                          'before:bg-slate-300 hover:text-slate-600',
+                          'hover:before:block dark:text-slate-400',
+                          'dark:before:bg-slate-700 dark:hover:text-slate-300'
+                        )}
                       >
                         {title}
                       </a>
@@ -57,17 +61,21 @@ const Guide: React.FC<Props> = ({ pages }) => {
   );
 };
 
-export async function getStaticProps() {
+export async function getStaticProps(): Promise<{ props: Props }> {
   const files = getFilesFromPath('guide');
 
-  const pages = files.map((filename) => {
+  const pages: Array<Page> = files.map(filename => {
     const slug = filename.replace('.md', '');
     const markDownWithMeta = getMarkDownWithMeta('guide', filename);
 
-    const { data: frontmatter } = matter(markDownWithMeta);
+    const { data, content } = matter(markDownWithMeta);
+    // This is safe because we're reading our own markdown, not user-submitted markdown.
+    const markdown = unsafeMarkdownFromContent(content);
+
     return {
       slug,
-      frontmatter,
+      frontmatter: requireFrontmatterDuringBuild(data),
+      markdown,
     };
   });
 

--- a/docs/pages/packages/[slug].tsx
+++ b/docs/pages/packages/[slug].tsx
@@ -1,12 +1,12 @@
-import { marked } from 'marked';
 import Link from 'next/link';
+import Markdown from '../../components/Markdown';
 import { getCombinedPackageData, getPackageDataFromSomeSlug, PackageData } from '../../GetPackages';
 
 interface Props {
   packageData: PackageData;
 }
 
-const PackagePage: React.FC<Props> = ({ packageData: { metadata, readme } }) => (
+const PackagePage: React.FC<Props> = ({ packageData: { metadata, markdown } }) => (
   <>
     <span>
       <Link href="/packages">
@@ -16,7 +16,7 @@ const PackagePage: React.FC<Props> = ({ packageData: { metadata, readme } }) => 
     <p>
       <strong>{metadata.name}</strong>: {metadata.description}
     </p>
-    <div dangerouslySetInnerHTML={{ __html: marked(readme) }}></div>
+    <Markdown markdown={markdown} />
   </>
 );
 
@@ -27,7 +27,11 @@ export async function getStaticPaths() {
     .resolve();
 }
 
-export async function getStaticProps({ params: { slug } }: { params: { slug: string } }) {
+export async function getStaticProps({
+  params: { slug },
+}: {
+  params: { slug: string };
+}): Promise<{ props: Props }> {
   return getPackageDataFromSomeSlug(slug)
     .map(packageData => ({ props: { packageData } }))
     .resolve();

--- a/docs/styles/globals.css
+++ b/docs/styles/globals.css
@@ -2,3 +2,7 @@
 @import './tailwind/components';
 @import './tailwind/utils';
 @import './fontawesome';
+
+code {
+  white-space: pre-wrap;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,6 +2730,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+highlight.js@^11.5.1:
+  version "11.5.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.5.1.tgz#027c24e4509e2f4dcd00b4a6dda542ce0a1f7aea"
+  integrity sha512-LKzHqnxr4CrD2YsNoIf/o5nJ09j4yi/GcH5BnYz9UnVpZdS4ucMgvP61TDty5xJcFGRjnH4DpujkS9bHT3hq0Q==
+
 hoist-non-react-statics@^3.0.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"


### PR DESCRIPTION
Followed the example here: https://marked.js.org/using_advanced

![image](https://user-images.githubusercontent.com/7213059/176949284-145b1591-fee0-4d44-b2eb-fce0c13b8669.png)
