### PR TITLE
Remove Honeybadger as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Most CooperTS packages are utility packages that build on primitive functional t
 - [`decoders`](https://github.com/execonline-inc/CooperTS/tree/master/packages/decoders) - Provides useful utility decoder implementations (see `jsonous`)
 - [`dom`](https://github.com/execonline-inc/CooperTS/tree/master/packages/dom) - Manipulate the HTML dom using Tasks (see `taskarian`)
 - [`environment`](https://github.com/execonline-inc/CooperTS/tree/master/packages/environment) - Provides functions to read from the execution environment
-- [`logging`](https://github.com/execonline-inc/CooperTS/tree/master/packages/logging) - Provides a few logging functions and also exports [`Honeybadger`](https://www.honeybadger.io/)
+- [`logging`](https://github.com/execonline-inc/CooperTS/tree/master/packages/logging) - Provides a few logging functions
 - [`maybe-adapter`](https://github.com/execonline-inc/CooperTS/tree/master/packages/maybe-adapter) - Provides functions to convert to/from `Maybe` types (see `maybeasy`)
 - [`numbers`](https://github.com/execonline-inc/CooperTS/tree/master/packages/numbers) - Parse strings into numbers
 - [`url`](https://github.com/execonline-inc/CooperTS/tree/master/packages/url) - Provides functions to validate URLs
@@ -26,7 +26,6 @@ Other CooperTS packages provide types & patterns for developers to conform to kn
 - [`translations`](https://github.com/execonline-inc/CooperTS/tree/master/packages/translations) - Provides support for typed translation keys and typed React-based translation interpolation using the [i18next](https://www.i18next.com/) library with a custom adapter
 - [`time`](https://github.com/execonline-inc/CooperTS/tree/master/packages/time) - Provides interfaces and functions for dealing with time durations
 - [`time-distance`](https://github.com/execonline-inc/CooperTS/tree/master/packages/time-distance) - Provides interfaces and functions for dealing with distances between dates
-
 
 See also the lower-level packages at [`festive-possum`](https://github.com/kofno/festive-possum), especially:
 

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@kofno/piper": "^4.3.0",
     "ajaxian": "^4.4.0",
-    "honeybadger-js": "^2.0.0",
     "jsonous": "^7.3.0",
     "logging": "^3.2.0",
     "maybeasy": "^3.0.0",

--- a/packages/environment/yarn.lock
+++ b/packages/environment/yarn.lock
@@ -70,11 +70,6 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-honeybadger-js@^2.0.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/honeybadger-js/-/honeybadger-js-2.2.2.tgz#53b345abcbb39740cd2229683f36959316f947bc"
-  integrity sha512-dRdTngkp5oqZ7076DDDMle/XHvMuPDXrh35tFkAGJIUabWMj71IODRm9ggLenDF2XxfB6FjrK4Ry5YixZTM4Ug==
-
 jsonous@^7.3.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/jsonous/-/jsonous-7.3.0.tgz#b6f1a1c3b35fac21859ccb527429871063dfe8da"

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -2,8 +2,6 @@
 
 The `logging` package provides a few logging functions.
 
-It also exports `Honeybadger` to provide a single point of configuration and use for that service's API.
-
 ## Functions
 
 ### `logger`
@@ -74,7 +72,9 @@ _Specific to ExecOnline_
 This function accepts an error name, an error message, and a context object. It sends the message to the console using `warn`, and also uses the provided information to post a notification to the third-party [Honeybadger](https://www.honeybadger.io/) exception monitoring service.
 
 ```ts
-import { warnAndNotify } from '@execonline-inc/logging';
+import { warnAndNotify as warnAndNotifyImpl } from '@execonline-inc/logging';
+
+export const warnAndNotify = warnAndNotifyImpl(Honeybadger.notify);
 
 const context = { user_id: 123 };
 warnAndNotify('ErrorName', 'Some error message', context);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2553,11 +2553,6 @@ hoist-non-react-statics@^3.0.0:
   dependencies:
     react-is "^16.7.0"
 
-honeybadger-js@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/honeybadger-js/-/honeybadger-js-2.3.0.tgz#040200066d60a8c1eca036e9f8568f9cff8b8d55"
-  integrity sha512-Tq1jPNumPe/l5RRDPDi+KNGULoaJQ9BSVZC+TEZOlPUzJx3AUn5ESb2NkCd7oSx/J221/aWUfz2/JrltHldx7A==
-
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"


### PR DESCRIPTION
For some reason, the `environment` package had Honeybadger as a dependency, but none of the CooperTS packages actually depend on it. And users of the library are supposed to have Honeybadger as a direct dependency themselves so CooperTS should not be providing it or dictating its version.