### PR TITLE
Remove mobx dependency from translations package

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,8 @@
     "highlight.js": "^11.5.1",
     "jsonous": "^7.3.0",
     "marked": "^4.0.17",
+    "mobx": "^4.15.7",
+    "mobx-react": "^5.4.4",
     "next": "12.1.6",
     "react": "18.1.0",
     "react-dom": "18.1.0"

--- a/packages/translations/package.json
+++ b/packages/translations/package.json
@@ -35,8 +35,6 @@
     "htmlparser2": "^4.1.0",
     "jsonous": "^7.3.0",
     "maybeasy": "^3.0.0",
-    "mobx": "^4.15.7",
-    "mobx-react": "^5.4.4",
     "nonempty-list": "^3.3.0",
     "resulty": "^5.0.0",
     "taskarian": "^5.1.0"

--- a/packages/translations/src/AlreadyTranslated.tsx
+++ b/packages/translations/src/AlreadyTranslated.tsx
@@ -1,4 +1,3 @@
-import { observer } from 'mobx-react';
 import * as React from 'react';
 import { AlreadyTranslatedText } from './types';
 
@@ -8,4 +7,4 @@ interface Props {
 
 const AlreadyTranslated: React.FC<Props> = ({ content }) => <>{content.text}</>;
 
-export default observer(AlreadyTranslated);
+export default AlreadyTranslated;

--- a/packages/translations/src/L.tsx
+++ b/packages/translations/src/L.tsx
@@ -1,4 +1,3 @@
-import { observer } from 'mobx-react';
 import * as React from 'react';
 import { localizer } from './localizations';
 import TranslationsContext from './TranslationsContext';
@@ -13,4 +12,4 @@ const L: React.FC<Props> = ({ localizeable, format }) => (
   <TranslationsContext.Consumer>{localizer(localizeable, format)}</TranslationsContext.Consumer>
 );
 
-export default observer(L);
+export default L;

--- a/packages/translations/src/NotTranslated.tsx
+++ b/packages/translations/src/NotTranslated.tsx
@@ -1,4 +1,3 @@
-import { observer } from 'mobx-react';
 import * as React from 'react';
 
 interface Props {
@@ -7,4 +6,4 @@ interface Props {
 
 const NotTranslated: React.FC<Props> = ({ text }) => <>{text}</>;
 
-export default observer(NotTranslated);
+export default NotTranslated;

--- a/packages/translations/src/translations.tsx
+++ b/packages/translations/src/translations.tsx
@@ -3,7 +3,6 @@ import { warn } from '@execonline-inc/logging';
 import { toResult } from '@execonline-inc/maybe-adapter';
 import { identity } from '@kofno/piper';
 import { fromNullable } from 'maybeasy';
-import { observer } from 'mobx-react';
 import * as React from 'react';
 import { err, ok, Result } from 'resulty';
 import L from './L';
@@ -196,9 +195,9 @@ export const translations = <
       .getOrElse(() => <React.Fragment key={kind}>{t}</React.Fragment>);
   };
 
-  const T: React.FC<PropsT> = observer((tProps: PropsT) => (
+  const T: React.FC<PropsT> = (tProps: PropsT) => (
     <TranslationsContext.Consumer>{translator(tProps)}</TranslationsContext.Consumer>
-  ));
+  );
 
   return {
     L,


### PR DESCRIPTION
The mobx packages version needs to align with any installation in consuming apps and this is an unreasonable requirement to impose.

The docs required it as a dependency but were using the shared workspace node modules to use mobx from the declaration in the translations package, so they needed to be added to its own package.json.

I tried testing this change in a consuming app locally, but our Docker setup makes this really difficult so I couldn't do it. I think we'll just need to release this change first.