### PR TITLE
Remove anchor tags within NextJS's Link component

### DIFF
--- a/docs/components/CardLinks/CardLink.tsx
+++ b/docs/components/CardLinks/CardLink.tsx
@@ -20,22 +20,22 @@ const CardLink: React.FC<Props> = ({ href, title, subtitle }) => (
       )}
     />
     <div className="relative overflow-hidden rounded-xl p-6">
-      <Link href={href} className="relative overflow-hidden rounded-xl p-6">
-        <a href={href} aria-label={title} aria-describedby="grid-learn-desc">
-          <h2
-            className={clsx(
-              'inline-flex font-display text-base text-slate-900',
-              ' dark:text-white'
-            )}
-            aria-label={title}
-          >
-            <span className="absolute -inset-px rounded-xl" />
-            {title}{' '}
-            <span className="ml-3 text-amber-500" aria-hidden="true">
-              <i className="fa fas fa-arrow-right"></i>
-            </span>
-          </h2>
-        </a>
+      <Link
+        href={href}
+        className="relative overflow-hidden rounded-xl p-6"
+        aria-label={title}
+        aria-describedby="grid-learn-desc"
+      >
+        <h2
+          className={clsx('inline-flex font-display text-base text-slate-900', ' dark:text-white')}
+          aria-label={title}
+        >
+          <span className="absolute -inset-px rounded-xl" />
+          {title}{' '}
+          <span className="ml-3 text-amber-500" aria-hidden="true">
+            <i className="fa fas fa-arrow-right"></i>
+          </span>
+        </h2>
       </Link>
       <p id="grid-learn-desc" className="mt-1 text-sm text-slate-700 dark:text-slate-400">
         {subtitle}

--- a/docs/components/Header/Header.tsx
+++ b/docs/components/Header/Header.tsx
@@ -30,24 +30,23 @@ const Header: React.FC = () => {
           'dark:[@supports(backdrop-filter:blur(0))]:bg-slate-900/75] dark:bg-slate-900/95 dark:backdrop-blur':
             isScrolled,
           'dark:bg-transparent': !isScrolled,
-        },
+        }
       )}
     >
       <div
         className={clsx(
           'content-container-width mx-auto py-3',
-          'flex items-center justify-between space-x-6',
+          'flex items-center justify-between space-x-6'
         )}
       >
-        <Link href="/">
-          <a
-            className={clsx(
-              'text-base font-bold text-green-600 hover:text-indigo-900',
-              'dark:text-green-300 dark:hover:text-indigo-300 sm:text-lg',
-            )}
-          >
-            CooperTS
-          </a>
+        <Link
+          href="/"
+          className={clsx(
+            'text-base font-bold text-green-600 hover:text-indigo-900',
+            'dark:text-green-300 dark:hover:text-indigo-300 sm:text-lg'
+          )}
+        >
+          CooperTS
         </Link>
         <nav
           className={`md:text-md flex items-center space-x-5 text-sm sm:space-x-10 sm:text-sm`}
@@ -58,20 +57,22 @@ const Header: React.FC = () => {
           <ItemLink href={'/examples'}>Examples</ItemLink>
           <ItemLink href={'/faq'}>FAQs</ItemLink>
           <ItemLink href={'/packages'}>Packages</ItemLink>
-          <Link href="https://github.com/execonline-inc/CooperTS" target={'_blank'}>
-            <a className="group">
-              <span className="sr-only">CooperTS on GitHub</span>
-              <svg
-                aria-hidden="true"
-                viewBox="0 0 16 16"
-                className={clsx(
-                  'h-6 w-6 fill-slate-500 group-hover:fill-slate-700',
-                  'dark:fill-slate-300 dark:group-hover:fill-white',
-                )}
-              >
-                <path d="M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z" />
-              </svg>
-            </a>
+          <Link
+            href="https://github.com/execonline-inc/CooperTS"
+            target={'_blank'}
+            className="group"
+          >
+            <span className="sr-only">CooperTS on GitHub</span>
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 16 16"
+              className={clsx(
+                'h-6 w-6 fill-slate-500 group-hover:fill-slate-700',
+                'dark:fill-slate-300 dark:group-hover:fill-white'
+              )}
+            >
+              <path d="M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z" />
+            </svg>
           </Link>
         </nav>
       </div>

--- a/docs/components/Header/ItemLink.tsx
+++ b/docs/components/Header/ItemLink.tsx
@@ -8,15 +8,14 @@ interface Props {
 }
 
 const ItemLink: React.FC<Props> = ({ href, children }) => (
-  <Link href={href}>
-    <a
-      className={clsx(
-        'font-medium text-gray-600 hover:text-gray-900',
-        'dark:text-gray-300 dark:hover:text-white',
-      )}
-    >
-      {children}
-    </a>
+  <Link
+    href={href}
+    className={clsx(
+      'font-medium text-gray-600 hover:text-gray-900',
+      'dark:text-gray-300 dark:hover:text-white'
+    )}
+  >
+    {children}
   </Link>
 );
 

--- a/docs/components/NavLinks/index.tsx
+++ b/docs/components/NavLinks/index.tsx
@@ -12,7 +12,7 @@ const NavLinks: React.FC<Props> = ({ navTree }) => (
     <div
       className={clsx(
         'sticky top-[4.5rem] -ml-0.5 h-[calc(100vh-4.5rem)]',
-        'overflow-y-auto py-16 pl-0.5',
+        'overflow-y-auto py-16 pl-0.5'
       )}
     >
       <nav className={clsx('w-64 pr-8 text-base lg:text-sm xl:w-72 xl:pr-16')}>
@@ -22,34 +22,31 @@ const NavLinks: React.FC<Props> = ({ navTree }) => (
               key={section.title}
               className={clsx('font-display font-medium text-slate-900 dark:text-white')}
             >
-              <Link href={section.href}>
-                <a>{section.title}</a>
-              </Link>
+              <Link href={section.href}>{section.title}</Link>
               <ul
                 className={clsx(
                   'not-prose lg:border-slate-20',
                   'mt-6 space-y-2 border-l-2',
                   'border-slate-100 dark:border-slate-800',
-                  'lg:mt-4 lg:space-y-4',
+                  'lg:mt-4 lg:space-y-4'
                 )}
               >
                 {section.links.map((link) => (
                   <li key={link.title} className={clsx('relative')}>
-                    <Link href={link.href}>
-                      <a
-                        className={clsx(
-                          'block w-full pl-3.5',
-                          'text-slate-500',
-                          'before:pointer-events-none before:absolute before:-left-1',
-                          'before:top-1/2 before:hidden before:h-1.5 before:w-1.5',
-                          'before:-translate-y-1/2 before:rounded-full',
-                          'before:bg-slate-300 hover:text-slate-600',
-                          'hover:before:block dark:text-slate-400',
-                          'dark:before:bg-slate-700 dark:hover:text-slate-300',
-                        )}
-                      >
-                        {link.title}
-                      </a>
+                    <Link
+                      href={link.href}
+                      className={clsx(
+                        'block w-full pl-3.5',
+                        'text-slate-500',
+                        'before:pointer-events-none before:absolute before:-left-1',
+                        'before:top-1/2 before:hidden before:h-1.5 before:w-1.5',
+                        'before:-translate-y-1/2 before:rounded-full',
+                        'before:bg-slate-300 hover:text-slate-600',
+                        'hover:before:block dark:text-slate-400',
+                        'dark:before:bg-slate-700 dark:hover:text-slate-300'
+                      )}
+                    >
+                      {link.title}
                     </Link>
                   </li>
                 ))}

--- a/docs/pages/faq.tsx
+++ b/docs/pages/faq.tsx
@@ -46,21 +46,20 @@ const FAQ: React.FC<Props> = ({ pages }) => {
                 >
                   {pages.map(({ slug, frontmatter: { title } }) => (
                     <li key={slug} className={clsx('relative')}>
-                      <Link href={`/faq/${slug}`}>
-                        <a
-                          className={clsx(
-                            'block w-full pl-3.5',
-                            'text-slate-500',
-                            'before:pointer-events-none before:absolute before:-left-1',
-                            'before:top-1/2 before:hidden before:h-1.5 before:w-1.5',
-                            'before:-translate-y-1/2 before:rounded-full',
-                            'before:bg-slate-300 hover:text-slate-600',
-                            'hover:before:block dark:text-slate-400',
-                            'dark:before:bg-slate-700 dark:hover:text-slate-300'
-                          )}
-                        >
-                          {title}
-                        </a>
+                      <Link
+                        href={`/faq/${slug}`}
+                        className={clsx(
+                          'block w-full pl-3.5',
+                          'text-slate-500',
+                          'before:pointer-events-none before:absolute before:-left-1',
+                          'before:top-1/2 before:hidden before:h-1.5 before:w-1.5',
+                          'before:-translate-y-1/2 before:rounded-full',
+                          'before:bg-slate-300 hover:text-slate-600',
+                          'hover:before:block dark:text-slate-400',
+                          'dark:before:bg-slate-700 dark:hover:text-slate-300'
+                        )}
+                      >
+                        {title}
                       </Link>
                     </li>
                   ))}

--- a/docs/pages/guide.tsx
+++ b/docs/pages/guide.tsx
@@ -46,21 +46,20 @@ const Guide: React.FC<Props> = ({ pages }) => {
                 >
                   {pages.map(({ slug, frontmatter: { title } }) => (
                     <li key={slug} className={clsx('relative')}>
-                      <Link href={`/guide/${slug}`}>
-                        <a
-                          className={clsx(
-                            'block w-full pl-3.5',
-                            'text-slate-500',
-                            'before:pointer-events-none before:absolute before:-left-1',
-                            'before:top-1/2 before:hidden before:h-1.5 before:w-1.5',
-                            'before:-translate-y-1/2 before:rounded-full',
-                            'before:bg-slate-300 hover:text-slate-600',
-                            'hover:before:block dark:text-slate-400',
-                            'dark:before:bg-slate-700 dark:hover:text-slate-300'
-                          )}
-                        >
-                          {title}
-                        </a>
+                      <Link
+                        href={`/guide/${slug}`}
+                        className={clsx(
+                          'block w-full pl-3.5',
+                          'text-slate-500',
+                          'before:pointer-events-none before:absolute before:-left-1',
+                          'before:top-1/2 before:hidden before:h-1.5 before:w-1.5',
+                          'before:-translate-y-1/2 before:rounded-full',
+                          'before:bg-slate-300 hover:text-slate-600',
+                          'hover:before:block dark:text-slate-400',
+                          'dark:before:bg-slate-700 dark:hover:text-slate-300'
+                        )}
+                      >
+                        {title}
                       </Link>
                     </li>
                   ))}

--- a/docs/pages/packages.tsx
+++ b/docs/pages/packages.tsx
@@ -20,9 +20,7 @@ const Packages: React.FC<Props> = ({ allPackageData }) => {
           .map(({ slug, metadata: { name, description } }) => (
             <li key={slug}>
               <Link href={`/packages/${slug}`}>
-                <a>
-                  <strong>{name}</strong>
-                </a>
+                <strong>{name}</strong>
               </Link>
               : {description}
             </li>


### PR DESCRIPTION
As part of the migration from Next 12 to 13, the Link component no longer accepts an anchor tag as a child.

https://nextjs.org/docs/upgrading#link-component

Part of https://github.com/execonline-inc/CooperTS/pull/89

The docsite runs fine with this change.