### PR TITLE
Upgrade the version of i18next to address some CVEs and add translations tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 packages/*/lib
 .idea
 .vscode/
+.serena/
 
 # Yarn with zero-installs
 .yarn/*

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "root",
@@ -79,7 +80,7 @@
     },
     "packages/appy": {
       "name": "@execonline-inc/appy",
-      "version": "9.9.0",
+      "version": "9.10.0",
       "dependencies": {
         "@execonline-inc/environment": "workspace:^",
         "@execonline-inc/resource": "workspace:^",
@@ -98,7 +99,7 @@
     },
     "packages/collections": {
       "name": "@execonline-inc/collections",
-      "version": "11.9.0",
+      "version": "11.10.0",
       "dependencies": {
         "@execonline-inc/maybe-adapter": "workspace:^",
         "@kofno/piper": "^5.0.1",
@@ -115,7 +116,7 @@
     },
     "packages/decoders": {
       "name": "@execonline-inc/decoders",
-      "version": "7.7.0",
+      "version": "7.8.0",
       "dependencies": {
         "@execonline-inc/time": "workspace:^",
         "js-base64": "^3.7.2",
@@ -130,7 +131,7 @@
     },
     "packages/dom": {
       "name": "@execonline-inc/dom",
-      "version": "4.7.0",
+      "version": "4.8.0",
       "dependencies": {
         "@kofno/piper": "^5.0.1",
         "@types/node": "^20.11.30",
@@ -142,7 +143,7 @@
     },
     "packages/environment": {
       "name": "@execonline-inc/environment",
-      "version": "6.9.0",
+      "version": "6.10.0",
       "dependencies": {
         "@kofno/piper": "^5.0.1",
         "ajaxian": "^5.5.0",
@@ -158,7 +159,7 @@
     },
     "packages/error-handling": {
       "name": "@execonline-inc/error-handling",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "dependencies": {
         "@kofno/piper": "^5.0.1",
         "maybeasy": "^7.1.0",
@@ -172,7 +173,7 @@
     },
     "packages/logging": {
       "name": "@execonline-inc/logging",
-      "version": "7.6.0",
+      "version": "7.7.0",
       "dependencies": {
         "@execonline-inc/environment": "workspace:^",
         "date-fns": "^2.28.0",
@@ -184,7 +185,7 @@
     },
     "packages/maybe-adapter": {
       "name": "@execonline-inc/maybe-adapter",
-      "version": "5.9.0",
+      "version": "5.10.0",
       "dependencies": {
         "@kofno/piper": "^5.0.1",
         "ajaxian": "^5.5.0",
@@ -200,7 +201,7 @@
     },
     "packages/numbers": {
       "name": "@execonline-inc/numbers",
-      "version": "5.6.0",
+      "version": "5.7.0",
       "dependencies": {
         "@execonline-inc/maybe-adapter": "workspace:^",
         "@kofno/piper": "^5.0.1",
@@ -216,7 +217,7 @@
     },
     "packages/resource": {
       "name": "@execonline-inc/resource",
-      "version": "7.9.0",
+      "version": "7.10.0",
       "dependencies": {
         "@execonline-inc/collections": "workspace:^",
         "@execonline-inc/decoders": "workspace:^",
@@ -236,7 +237,7 @@
     },
     "packages/strings": {
       "name": "@execonline-inc/strings",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "dependencies": {
         "@kofno/piper": "^5.0.1",
         "maybeasy": "^7.1.0",
@@ -247,7 +248,7 @@
     },
     "packages/time": {
       "name": "@execonline-inc/time",
-      "version": "6.6.0",
+      "version": "6.7.0",
       "dependencies": {
         "resulty": "^8.0.0",
       },
@@ -259,7 +260,7 @@
     },
     "packages/time-distance": {
       "name": "@execonline-inc/time-distance",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "dependencies": {
         "@execonline-inc/time": "workspace:^",
         "resulty": "^8.0.0",
@@ -271,14 +272,14 @@
     },
     "packages/translations": {
       "name": "@execonline-inc/translations",
-      "version": "11.4.0",
+      "version": "11.5.0",
       "dependencies": {
         "@execonline-inc/collections": "workspace:^",
         "@execonline-inc/logging": "workspace:^",
         "@execonline-inc/maybe-adapter": "workspace:^",
         "@kofno/piper": "^5.0.1",
-        "@prebsch-exo/i18next": "19.9.2-patch.1",
         "htmlparser2": "^4.1.0",
+        "i18next": "^26.0.6",
         "jsonous": "^12.1.0",
         "maybeasy": "^7.1.0",
         "nonempty-list": "^4.2.0",
@@ -296,7 +297,7 @@
     },
     "packages/url": {
       "name": "@execonline-inc/url",
-      "version": "9.6.0",
+      "version": "9.7.0",
       "dependencies": {
         "@kofno/piper": "^5.0.1",
         "maybeasy": "^7.1.0",
@@ -314,7 +315,7 @@
     },
     "packages/web-url": {
       "name": "@execonline-inc/web-url",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "dependencies": {
         "@execonline-inc/error-handling": "workspace:^",
         "@kofno/piper": "^5.0.1",
@@ -593,8 +594,6 @@
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
-
-    "@prebsch-exo/i18next": ["@prebsch-exo/i18next@19.9.2-patch.1", "", { "dependencies": { "@babel/runtime": "^7.12.0" } }, "sha512-jovnIKWPOQ9rKs9fPjEzDlwvtcY4AR+/FoWCNC5gjtoKSyEFr1isxChEdr3ysiVlVmsuaRLO9TjGWWoN9GA8cQ=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.34.9", "", { "os": "android", "cpu": "arm" }, "sha512-qZdlImWXur0CFakn2BJ2znJOdqYZKiedEPEVNTBrpfPjc/YuTGcaYZcdmNFTkUj3DU0ZM/AElcM8Ybww3xVLzA=="],
 
@@ -1253,6 +1252,8 @@
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+
+    "i18next": ["i18next@26.0.8", "", { "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-BRzLom0mhDhV9v0QhgUUHWQJuwFmnr1194xEcNLYD6ym8y8s542n4jXUvRLnhNTbh9PmpU6kGZamyuGHQMsGjw=="],
 
     "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 

--- a/packages/translations/__tests__/translations.test.js
+++ b/packages/translations/__tests__/translations.test.js
@@ -1,7 +1,0 @@
-'use strict';
-
-const translations = require('..');
-
-describe('translations', () => {
-  it('has no tests');
-});

--- a/packages/translations/__tests__/translations.test.ts
+++ b/packages/translations/__tests__/translations.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'bun:test';
+import i18next from 'i18next';
+import {
+  alreadyTranslated,
+  alreadyTranslatedText,
+  defaultSettings,
+  initTask,
+  languageTag,
+  loaded,
+  loadedFromFallback,
+  translations,
+} from '../src';
+import type { Loaded, LoadedFromFallback, Translator, Uninitialized } from '../src';
+
+const fakeTranslator: Translator = (key, _options) => `t:${key}`;
+
+describe('defaultSettings', () => {
+  it('declares the translations namespace', () => {
+    expect(defaultSettings.ns).toEqual(['translations']);
+    expect(defaultSettings.defaultNS).toBe('translations');
+  });
+
+  it('falls back to english', () => {
+    expect(defaultSettings.fallbackLng).toBe('en');
+  });
+
+  it('disables key/namespace separators so dots in keys are preserved', () => {
+    expect(defaultSettings.keySeparator).toBe(false);
+    expect(defaultSettings.nsSeparator).toBe(false);
+  });
+
+  it('disables react-style escaping in interpolation', () => {
+    expect(defaultSettings.interpolation?.escapeValue).toBe(false);
+  });
+});
+
+describe('initTask (i18next adapter)', () => {
+  it('resolves with a Loaded state, language, and translator on successful init', async () => {
+    const result = await new Promise<Loaded | LoadedFromFallback>((resolve, reject) => {
+      initTask(i18next, {
+        ...defaultSettings,
+        lng: 'en',
+        debug: false,
+        resources: {
+          en: { translations: { hello: 'Hello', greet: 'Hi {{name}}' } },
+        },
+      }).fork(reject, resolve);
+    });
+
+    expect(result.kind).toBe('loaded');
+    expect(result.language).toBe('en');
+    expect(result.translator('hello', {})).toBe('Hello');
+    expect(result.translator('greet', { name: 'Ada' })).toBe('Hi Ada');
+  });
+});
+
+describe('translation', () => {
+  const plainKeys = ['hello', 'world'] as const;
+  const notTranslatable = ['user@example.com'] as const;
+  const { translation } = translations<
+    typeof plainKeys[number],
+    typeof notTranslatable[number],
+    never,
+    { kind: never }
+  >(plainKeys, notTranslatable, () => ({} as never));
+
+  it('returns the empty string for an uninitialized state', () => {
+    const state: Uninitialized = { kind: 'uninitialized' };
+    expect(translation('hello', {})(state)).toBe('');
+  });
+
+  it('looks up a key via the translator when loaded', () => {
+    const state = loaded(fakeTranslator, 'en');
+    expect(translation('hello', {})(state)).toBe('t:hello');
+  });
+
+  it('returns not-translatable keys unchanged without calling the translator', () => {
+    let called = false;
+    const trackingTranslator: Translator = (key, _options) => {
+      called = true;
+      return `t:${key}`;
+    };
+    const state = loaded(trackingTranslator, 'en');
+    expect(translation('user@example.com', {})(state)).toBe('user@example.com');
+    expect(called).toBe(false);
+  });
+
+  it('uses the translator even in the loaded-from-fallback state', () => {
+    const state = loadedFromFallback(fakeTranslator, 'en', 'boom');
+    expect(translation('world', {})(state)).toBe('t:world');
+  });
+});
+
+describe('alreadyTranslatedText decoder', () => {
+  it('decodes a string into an AlreadyTranslatedText', () => {
+    const result = alreadyTranslatedText.decodeAny('already done');
+    expect(result.getOrElseValue(alreadyTranslated('fallback'))).toEqual({
+      kind: 'already-translated-text',
+      text: 'already done',
+    });
+  });
+
+  it('fails to decode a non-string value', () => {
+    const result = alreadyTranslatedText.decodeAny(42);
+    expect(result.cata({ Ok: () => false, Err: () => true })).toBe(true);
+  });
+});
+
+describe('languageTag', () => {
+  it('returns the primary tag from a hyphenated language', () => {
+    expect(languageTag('en-US').getOrElseValue('')).toBe('en');
+    expect(languageTag('zh-Hant-TW').getOrElseValue('')).toBe('zh');
+  });
+
+  it('returns the input when no hyphen is present', () => {
+    expect(languageTag('fr').getOrElseValue('')).toBe('fr');
+  });
+});

--- a/packages/translations/package.json
+++ b/packages/translations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@execonline-inc/translations",
-  "version": "11.5.0",
+  "version": "12.0.0",
   "description": "Support for typed and interpolatable translations",
   "author": "Patrick Rebsch <pjrebsch@gmail.com>",
   "homepage": "https://github.com/execonline-inc/CooperTS#readme",
@@ -35,8 +35,8 @@
     "@execonline-inc/logging": "workspace:^",
     "@execonline-inc/maybe-adapter": "workspace:^",
     "@kofno/piper": "^5.0.1",
-    "@prebsch-exo/i18next": "19.9.2-patch.1",
     "htmlparser2": "^4.1.0",
+    "i18next": "^26.0.6",
     "jsonous": "^12.1.0",
     "maybeasy": "^7.1.0",
     "nonempty-list": "^4.2.0",

--- a/packages/translations/src/adapters/i18next/index.ts
+++ b/packages/translations/src/adapters/i18next/index.ts
@@ -1,6 +1,6 @@
 import { warn } from '@execonline-inc/logging';
 import { noop } from '@kofno/piper';
-import i18next, * as i18n from '@prebsch-exo/i18next';
+import i18next, * as i18n from 'i18next';
 import { Task } from 'taskarian';
 import { loaded, loadedFromFallback } from '../../translations';
 import { Loader } from '../../types';
@@ -27,7 +27,7 @@ export const initTask = (initializer: i18n.i18n, options: i18n.InitOptions): Loa
           resolve(loaded(translator, i18next.language));
         }
       })
-      .catch(err => warn(err));
+      .catch((err) => warn(err));
 
     return noop;
   });


### PR DESCRIPTION
## Summary

  Replace the `@prebsch-exo/i18next@19.9.2-patch.1` fork with the upstream `i18next@^26.0.6` in `@execonline-inc/translations`, and add real tests for the package (it previously had only a broken placeholder).

  - **Dependency swap**: `@prebsch-exo/i18next` → `i18next` (skipping ~7 major versions of upstream changes; the v19 fork was a long-stale patch release)
  - **Package bump**: `@execonline-inc/translations` 11.5.0 → 12.0.0 (breaking dep change for consumers)
  - **Tests**: added 13 passing tests covering the i18next adapter init, the `translation` state machine, the `alreadyTranslatedText` decoder, and `languageTag`; removed the prior placeholder that wasn't even a valid test.

  ## Why now

  The `@prebsch-exo/i18next` fork hasn't moved in years and pinned us to v19-era APIs. Upstream `i18next` is at v26 with active maintenance, CLDR-based plural rules via `Intl`, and current TypeScript definitions. The init
  API surface this adapter relies on (`init(options, callback)` returning a `Promise`) is unchanged across the gap, so the swap is mechanical.

  ## Changes

  ### `packages/translations/package.json`
  ```diff
  -    "@prebsch-exo/i18next": "19.9.2-patch.1",
       "htmlparser2": "^4.1.0",
  +    "i18next": "^26.0.6",
  ```
  Version bumped to `12.0.0`.

  ### `packages/translations/src/adapters/i18next/index.ts`
  ```diff
  -import i18next, * as i18n from '@prebsch-exo/i18next';
  +import i18next, * as i18n from 'i18next';
  ```

  ### `packages/translations/__tests__/translations.test.ts` (new)
  Replaces the broken `translations.test.js` placeholder. Covers:

  - `defaultSettings` shape — guards `ns`/`defaultNS`/`fallbackLng`/`keySeparator`/`nsSeparator`/`interpolation.escapeValue`
  - `initTask` — end-to-end check that v26 init resolves a `Loaded` state with the right language and a working translator (including `{{name}}` interpolation)
  - `translation` — uninitialized → empty string; loaded → translator lookup; not-translatable keys → returned unchanged without invoking the translator; loaded-from-fallback → still uses the translator
  - `alreadyTranslatedText` — decodes strings; rejects non-strings
  - `languageTag` — strips region/script (`en-US` → `en`, `zh-Hant-TW` → `zh`); passes through when no hyphen

  Tests run via `bun test` and import from `../src` directly so they don't depend on a prior build.

  ## Compatibility notes for downstream consumers

  The `initTask`/`defaultSettings` API is unchanged, but consumers' translation **content** may be affected by upstream i18next changes between v19 and v26:

  - **Plural rules**: i18next moved from `compatibilityJSON: 'v3'` to Intl/CLDR-based plurals. JSON keys like `key_plural` no longer match — use `key_one` / `key_other` etc., **or** pass `compatibilityJSON: 'v3'` in your
  settings override.
  - **Init still callback-compatible**: `init(options, (err, t) => …)` works as before; no changes required in consumer init code.

  ## Known pre-existing quirk (out of scope here)

  While writing the init test I noticed `adapters/i18next/index.ts` lines 25 & 27 read `i18next.language` (the global default instance) instead of `initializer.language` (the argument). Consumers who pass a custom instance
  via `i18next.createInstance()` will see `Loaded.language` as `undefined`. Not introduced by this PR; happy to file a follow-up.